### PR TITLE
Adjust country grid responsiveness

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -432,13 +432,14 @@ h1, h2, h3, h4 {
 
 .country-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1.3rem;
+  align-items: stretch;
 }
 
 .country-layout {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: 1fr;
   gap: 1.4rem;
   margin-bottom: 2.8rem;
 }


### PR DESCRIPTION
## Summary
- align country cards within grids by adjusting minimum widths and stretch behaviour
- ensure Italy pillar cards default to a single column and shift into a tidy two-column grid on wider screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9499e26c8320b7b37bcb5a05c1b4)