### PR TITLE
Add navigation highlight and basic compare interaction

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,7 +11,6 @@
 
 <link rel="stylesheet" href="assets/css/style.css" />
 
-  <script defer src="assets/js/main.js"></script>
 </head>
 <body class="page-about">
   <header class="site-header">
@@ -100,6 +99,8 @@
       </p>
     </div>
   </footer>
+
+  <script src="assets/js/main.js"></script>
 </body>
 </html>
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,1 +1,46 @@
+// Basic site interactions for EU Migration Atlas
+// Highlights the current navigation link and powers simple compare UI feedback.
 
+document.addEventListener('DOMContentLoaded', () => {
+  highlightCurrentNav();
+  setupCompareInteractions();
+});
+
+function highlightCurrentNav() {
+  const bodyClass = Array.from(document.body.classList).find((cls) => cls.startsWith('page-'));
+  if (!bodyClass) return;
+
+  const currentPage = bodyClass.replace('page-', '');
+  const navLinks = document.querySelectorAll('.main-nav a[data-page]');
+
+  navLinks.forEach((link) => {
+    const linkPage = link.getAttribute('data-page');
+    if (linkPage === currentPage) {
+      link.classList.add('is-active');
+    }
+  });
+}
+
+function setupCompareInteractions() {
+  const selectA = document.getElementById('compare-country-a');
+  const selectB = document.getElementById('compare-country-b');
+  const labelA = document.getElementById('compare-label-a');
+  const labelB = document.getElementById('compare-label-b');
+  const headingA = document.querySelector('.compare-panel-a h2');
+  const headingB = document.querySelector('.compare-panel-b h2');
+
+  if (!selectA || !selectB || !labelA || !labelB || !headingA || !headingB) return;
+
+  const defaultLabel = 'No country selected yet';
+
+  const updatePanel = (selectEl, labelEl, headingEl, fallbackHeading) => {
+    const selectedOption = selectEl.options[selectEl.selectedIndex];
+    const hasValue = selectedOption && selectedOption.value;
+
+    labelEl.textContent = hasValue ? selectedOption.text : defaultLabel;
+    headingEl.textContent = hasValue ? selectedOption.text : fallbackHeading;
+  };
+
+  selectA.addEventListener('change', () => updatePanel(selectA, labelA, headingA, 'Country A'));
+  selectB.addEventListener('change', () => updatePanel(selectB, labelB, headingB, 'Country B'));
+}

--- a/assistant.html
+++ b/assistant.html
@@ -11,7 +11,6 @@
 
 <link rel="stylesheet" href="assets/css/style.css" />
 
-  <script defer src="assets/js/main.js"></script>
 </head>
 <body class="page-assistant">
   <header class="site-header">
@@ -87,6 +86,8 @@
       </p>
     </div>
   </footer>
+
+  <script src="assets/js/main.js"></script>
 </body>
 </html>
 

--- a/compare.html
+++ b/compare.html
@@ -11,7 +11,6 @@
 
 <link rel="stylesheet" href="assets/css/style.css" />
 
-  <script defer src="assets/js/main.js"></script>
 </head>
 <body class="page-compare">
   <header class="site-header">
@@ -152,6 +151,8 @@
       </p>
     </div>
   </footer>
+
+  <script src="assets/js/main.js"></script>
 </body>
 </html>
 

--- a/countries.html
+++ b/countries.html
@@ -11,7 +11,6 @@
 
 <link rel="stylesheet" href="assets/css/style.css" />
 
-  <script defer src="assets/js/main.js"></script>
 </head>
 <body class="page-countries">
   <header class="site-header">
@@ -86,6 +85,8 @@
       </p>
     </div>
   </footer>
+
+  <script src="assets/js/main.js"></script>
 </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
 
 <link rel="stylesheet" href="assets/css/style.css" />
 
-  <script defer src="assets/js/main.js"></script>
 </head>
 <body class="page-home">
   <header class="site-header">
@@ -141,5 +140,6 @@
     </div>
   </footer>
 
+  <script src="assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- highlight the active navigation link based on the current page
- add basic compare page interactions updating headers and labels when selections change
- load the shared script at the end of each main page body

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9c7e9e908320a4481c487d4aaced)