### PR TITLE
Add error message placeholder to compare page

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -63,6 +63,8 @@
             </select>
           </div>
         </form>
+
+        <p class="compare-error" id="compare-error" aria-live="polite"></p>
       </div>
 
       <div class="compare-grid">


### PR DESCRIPTION
## Summary
- add an empty compare error message container after the compare form for future validation feedback

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9fe63a28832081b43fd57d357b69)