### PR TITLE
Add compare validation and label update logic

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,46 +1,63 @@
-// Basic site interactions for EU Migration Atlas
-// Highlights the current navigation link and powers simple compare UI feedback.
-
 document.addEventListener('DOMContentLoaded', () => {
-  highlightCurrentNav();
-  setupCompareInteractions();
-});
+  const navLinks = document.querySelectorAll('header nav a, .site-nav a');
+  const currentPath = window.location.pathname.split('/').pop() || 'index.html';
 
-function highlightCurrentNav() {
-  const bodyClass = Array.from(document.body.classList).find((cls) => cls.startsWith('page-'));
-  if (!bodyClass) return;
+  navLinks.forEach(link => {
+    const href = link.getAttribute('href');
+    if (!href) return;
 
-  const currentPage = bodyClass.replace('page-', '');
-  const navLinks = document.querySelectorAll('.main-nav a[data-page]');
-
-  navLinks.forEach((link) => {
-    const linkPage = link.getAttribute('data-page');
-    if (linkPage === currentPage) {
+    const linkPath = href.split('/').pop();
+    if (linkPath === currentPath) {
       link.classList.add('is-active');
     }
   });
-}
 
-function setupCompareInteractions() {
   const selectA = document.getElementById('compare-country-a');
   const selectB = document.getElementById('compare-country-b');
-  const labelA = document.getElementById('compare-label-a');
-  const labelB = document.getElementById('compare-label-b');
-  const headingA = document.querySelector('.compare-panel-a h2');
-  const headingB = document.querySelector('.compare-panel-b h2');
+  const labelA  = document.getElementById('compare-label-a');
+  const labelB  = document.getElementById('compare-label-b');
+  const errorEl = document.getElementById('compare-error');
 
-  if (!selectA || !selectB || !labelA || !labelB || !headingA || !headingB) return;
+  let prevA = '';
+  let prevB = '';
 
-  const defaultLabel = 'No country selected yet';
+  function updateLabel(select, label, fallbackText) {
+    const option = select.options[select.selectedIndex];
+    label.textContent = option && option.value ? option.textContent : fallbackText;
+  }
 
-  const updatePanel = (selectEl, labelEl, headingEl, fallbackHeading) => {
-    const selectedOption = selectEl.options[selectEl.selectedIndex];
-    const hasValue = selectedOption && selectedOption.value;
+  function showError(message) {
+    if (!errorEl) return;
+    errorEl.textContent = message || '';
+  }
 
-    labelEl.textContent = hasValue ? selectedOption.text : defaultLabel;
-    headingEl.textContent = hasValue ? selectedOption.text : fallbackHeading;
-  };
+  if (selectA && selectB) {
+    selectA.addEventListener('focus', () => { prevA = selectA.value; });
+    selectB.addEventListener('focus', () => { prevB = selectB.value; });
 
-  selectA.addEventListener('change', () => updatePanel(selectA, labelA, headingA, 'Country A'));
-  selectB.addEventListener('change', () => updatePanel(selectB, labelB, headingB, 'Country B'));
-}
+    selectA.addEventListener('change', () => {
+      if (selectA.value && selectA.value === selectB.value) {
+        selectA.value = prevA;
+        updateLabel(selectA, labelA, 'No country selected yet');
+        showError('Country A and Country B must be different.');
+        return;
+      }
+      updateLabel(selectA, labelA, 'No country selected yet');
+      showError('');
+    });
+
+    selectB.addEventListener('change', () => {
+      if (selectB.value && selectB.value === selectA.value) {
+        selectB.value = prevB;
+        updateLabel(selectB, labelB, 'No country selected yet');
+        showError('Country A and Country B must be different.');
+        return;
+      }
+      updateLabel(selectB, labelB, 'No country selected yet');
+      showError('');
+    });
+
+    updateLabel(selectA, labelA, 'No country selected yet');
+    updateLabel(selectB, labelB, 'No country selected yet');
+  }
+});


### PR DESCRIPTION
## Summary
- highlight current nav link based on pathname for both header and site navigation
- add compare dropdown validation to prevent selecting same country and keep labels updated
- display inline error messaging when selections conflict

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa0c131b88320a79e5032f887a458)