### PR TITLE
Enhance compare layout with controls card, meta chips and icons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -718,6 +718,196 @@ h1, h2, h3, h4 {
   color: #b3261e;
 }
 
+/* Compare – controls card */
+
+.compare-controls {
+  margin-bottom: 2rem;
+}
+
+.compare-controls-card {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 1.25rem 1.5rem 1.4rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.compare-controls-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.compare-controls-text {
+  max-width: 420px;
+}
+
+.compare-controls-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: #4b5563;
+  margin-bottom: 0.15rem;
+}
+
+.compare-controls-helper {
+  font-size: 0.95rem;
+  color: #6b7280;
+}
+
+.compare-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  align-items: flex-end;
+}
+
+/* we hadden eerder al .compare-select-group select gestyled;
+   deze regels bouwen daarop voort */
+
+.compare-controls-summary {
+  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.compare-pill {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: #f1f5f9;
+  font-size: 0.9rem;
+}
+
+.compare-pill-a {
+  background: rgba(37, 99, 235, 0.06);
+}
+
+.compare-pill-b {
+  background: rgba(16, 185, 129, 0.06);
+}
+
+.compare-pill-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.78rem;
+  color: #6b7280;
+}
+
+.compare-pill-value {
+  font-weight: 500;
+  color: #111827;
+}
+
+.compare-controls-divider {
+  flex: 1;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #2563eb, #10b981);
+  opacity: 0.6;
+}
+
+/* foutmelding in context van de card */
+
+.compare-error {
+  margin-top: 0.6rem;
+  font-size: 0.9rem;
+  color: #b3261e;
+}
+
+/* Compare – panel meta */
+
+.compare-panel-header {
+  margin-bottom: 1rem;
+}
+
+.compare-panel-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+}
+
+.compare-panel-title-row h2 {
+  margin: 0;
+}
+
+.compare-country-label {
+  font-size: 0.95rem;
+  color: #6b7280;
+}
+
+.compare-meta {
+  margin-top: 0.35rem;
+}
+
+.compare-meta-line {
+  margin: 0 0 0.4rem;
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.compare-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.compare-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.04);
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+/* Compare – section icons */
+
+.compare-section-icon {
+  display: inline-flex;
+  width: 1.4rem;
+  justify-content: center;
+  margin-right: 0.35rem;
+  font-size: 1rem;
+  opacity: 0.9;
+}
+
+/* Kleine responsive tweaken */
+
+@media (max-width: 768px) {
+  .compare-controls-card {
+    padding: 1rem 1rem 1.2rem;
+  }
+
+  .compare-controls-header {
+    align-items: flex-start;
+  }
+
+  .compare-controls-text {
+    max-width: 100%;
+  }
+
+  .compare-controls-summary {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .compare-controls-divider {
+    width: 100%;
+  }
+}
+
 /* ============================
    4. ATLAS AI PAGE BASIS
    ============================ */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -17,13 +17,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const labelA  = document.getElementById('compare-label-a');
   const labelB  = document.getElementById('compare-label-b');
   const errorEl = document.getElementById('compare-error');
+  const pillA   = document.getElementById('compare-pill-a');
+  const pillB   = document.getElementById('compare-pill-b');
 
   let prevA = '';
   let prevB = '';
 
-  function updateLabel(select, label, fallbackText) {
+  function updateLabel(select, label, fallbackText, pill) {
     const option = select.options[select.selectedIndex];
-    label.textContent = option && option.value ? option.textContent : fallbackText;
+    const text = option && option.value ? option.textContent : fallbackText;
+    if (label) label.textContent = text;
+    if (pill)  pill.textContent  = option && option.value ? text : 'Not selected';
   }
 
   function showError(message) {
@@ -38,26 +42,26 @@ document.addEventListener('DOMContentLoaded', () => {
     selectA.addEventListener('change', () => {
       if (selectA.value && selectA.value === selectB.value) {
         selectA.value = prevA;
-        updateLabel(selectA, labelA, 'No country selected yet');
+        updateLabel(selectA, labelA, 'No country selected yet', pillA);
         showError('Country A and Country B must be different.');
         return;
       }
-      updateLabel(selectA, labelA, 'No country selected yet');
+      updateLabel(selectA, labelA, 'No country selected yet', pillA);
       showError('');
     });
 
     selectB.addEventListener('change', () => {
       if (selectB.value && selectB.value === selectA.value) {
         selectB.value = prevB;
-        updateLabel(selectB, labelB, 'No country selected yet');
+        updateLabel(selectB, labelB, 'No country selected yet', pillB);
         showError('Country A and Country B must be different.');
         return;
       }
-      updateLabel(selectB, labelB, 'No country selected yet');
+      updateLabel(selectB, labelB, 'No country selected yet', pillB);
       showError('');
     });
 
-    updateLabel(selectA, labelA, 'No country selected yet');
-    updateLabel(selectB, labelB, 'No country selected yet');
+    updateLabel(selectA, labelA, 'No country selected yet', pillA);
+    updateLabel(selectB, labelB, 'No country selected yet', pillB);
   }
 });

--- a/compare.html
+++ b/compare.html
@@ -42,27 +42,50 @@
       </header>
 
       <div class="compare-controls">
-        <form class="compare-form" aria-label="Compare countries form">
-          <div class="compare-select-group">
-            <label for="compare-country-a">Country A</label>
-            <select id="compare-country-a" name="countryA">
-              <option value="" selected disabled>Select a country</option>
-              <option value="italy">Italy</option>
-              <option value="germany">Germany</option>
-              <option value="france">France</option>
-            </select>
+        <div class="compare-controls-card">
+          <div class="compare-controls-header">
+            <div class="compare-controls-text">
+              <p class="compare-controls-label">Select countries to compare</p>
+              <p class="compare-controls-helper">
+                Choose two different EU Member States to generate a side-by-side comparison.
+              </p>
+            </div>
+
+            <form class="compare-form" aria-label="Compare countries form">
+              <div class="compare-select-group">
+                <label for="compare-country-a">Country A</label>
+                <select id="compare-country-a" name="countryA">
+                  <option value="" disabled selected>Select a country</option>
+                  <option value="italy">Italy</option>
+                  <option value="germany">Germany</option>
+                  <option value="france">France</option>
+                </select>
+              </div>
+
+              <div class="compare-select-group">
+                <label for="compare-country-b">Country B</label>
+                <select id="compare-country-b" name="countryB">
+                  <option value="" disabled selected>Select a country</option>
+                  <option value="italy">Italy</option>
+                  <option value="germany">Germany</option>
+                  <option value="france">France</option>
+                </select>
+              </div>
+            </form>
           </div>
 
-          <div class="compare-select-group">
-            <label for="compare-country-b">Country B</label>
-            <select id="compare-country-b" name="countryB">
-              <option value="" selected disabled>Select a country</option>
-              <option value="italy">Italy</option>
-              <option value="germany">Germany</option>
-              <option value="france">France</option>
-            </select>
+          <div class="compare-controls-summary">
+            <span class="compare-pill compare-pill-a">
+              <span class="compare-pill-label">Country A</span>
+              <span class="compare-pill-value" id="compare-pill-a">Not selected</span>
+            </span>
+            <span class="compare-controls-divider" aria-hidden="true"></span>
+            <span class="compare-pill compare-pill-b">
+              <span class="compare-pill-label">Country B</span>
+              <span class="compare-pill-value" id="compare-pill-b">Not selected</span>
+            </span>
           </div>
-        </form>
+        </div>
 
         <p class="compare-error" id="compare-error" aria-live="polite"></p>
       </div>
@@ -70,13 +93,25 @@
       <div class="compare-grid">
         <article class="compare-panel compare-panel-a">
           <header class="compare-panel-header">
-            <h2>Country A</h2>
-            <p class="compare-country-label" id="compare-label-a">No country selected yet</p>
+            <div class="compare-panel-title-row">
+              <h2>Country A</h2>
+              <p class="compare-country-label" id="compare-label-a">No country selected yet</p>
+            </div>
+            <div class="compare-meta">
+              <p class="compare-meta-line">
+                Placeholder political label for Country A.
+              </p>
+              <div class="compare-chips">
+                <span class="compare-chip">TBD stance</span>
+                <span class="compare-chip">TBD salience</span>
+                <span class="compare-chip">TBD EU alignment</span>
+              </div>
+            </div>
           </header>
 
           <div class="compare-panel-body">
             <section class="compare-block">
-              <h3>Political climate</h3>
+              <h3><span class="compare-section-icon">🧭</span>Political climate</h3>
               <p>
                 Placeholder text. This section will summarise the broader political context influencing
                 migration policy in the selected country.
@@ -84,7 +119,7 @@
             </section>
 
             <section class="compare-block">
-              <h3>Key migration policies</h3>
+              <h3><span class="compare-section-icon">📊</span>Key migration policies</h3>
               <ul>
                 <li>Asylum and reception</li>
                 <li>Border management</li>
@@ -94,7 +129,7 @@
             </section>
 
             <section class="compare-block">
-              <h3>Alignment with EU frameworks</h3>
+              <h3><span class="compare-section-icon">⚖️</span>Alignment with EU frameworks</h3>
               <p>
                 Short indication of how the national approach relates to CEAS and the EU Pact on
                 Migration and Asylum.
@@ -105,13 +140,25 @@
 
         <article class="compare-panel compare-panel-b">
           <header class="compare-panel-header">
-            <h2>Country B</h2>
-            <p class="compare-country-label" id="compare-label-b">No country selected yet</p>
+            <div class="compare-panel-title-row">
+              <h2>Country B</h2>
+              <p class="compare-country-label" id="compare-label-b">No country selected yet</p>
+            </div>
+            <div class="compare-meta">
+              <p class="compare-meta-line">
+                Placeholder political label for Country B.
+              </p>
+              <div class="compare-chips">
+                <span class="compare-chip">TBD stance</span>
+                <span class="compare-chip">TBD salience</span>
+                <span class="compare-chip">TBD EU alignment</span>
+              </div>
+            </div>
           </header>
 
           <div class="compare-panel-body">
             <section class="compare-block">
-              <h3>Political climate</h3>
+              <h3><span class="compare-section-icon">🧭</span>Political climate</h3>
               <p>
                 Placeholder text for the second country. This will highlight how domestic politics
                 shape migration debates and decisions.
@@ -119,7 +166,7 @@
             </section>
 
             <section class="compare-block">
-              <h3>Key migration policies</h3>
+              <h3><span class="compare-section-icon">📊</span>Key migration policies</h3>
               <ul>
                 <li>Asylum and reception</li>
                 <li>Border management</li>
@@ -129,7 +176,7 @@
             </section>
 
             <section class="compare-block">
-              <h3>Alignment with EU frameworks</h3>
+              <h3><span class="compare-section-icon">⚖️</span>Alignment with EU frameworks</h3>
               <p>
                 Placeholder for a short comparison between national policies and EU-level obligations
                 and objectives.


### PR DESCRIPTION
## Summary
- replace compare form with a richer controls card and pill summary for selections
- add panel metadata, chips, and section icons to both comparison panes
- style the new compare layout and sync the selection pills via JavaScript

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa316b65c832090b4629fbfaba4e0)