### PR TITLE
Add visual metric grid to compare panels

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -872,6 +872,63 @@ h1, h2, h3, h4 {
   color: #374151;
 }
 
+/* Compare – metric tiles */
+
+.compare-metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.compare-metric-tile {
+  background: #f8fafc;
+  border-radius: 0.9rem;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.04);
+}
+
+.compare-metric-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7280;
+  margin-bottom: 0.15rem;
+}
+
+.compare-metric-value {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #111827;
+}
+
+/* Voor later: niveaus met kleurverschil */
+
+.metric-level-low {
+  background: #ecfdf3;
+  border-color: #bbf7d0;
+  color: #166534;
+}
+
+.metric-level-medium {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+  color: #1d4ed8;
+}
+
+.metric-level-high {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+@media (max-width: 768px) {
+  .compare-metrics-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Compare – section icons */
 
 .compare-section-icon {

--- a/compare.html
+++ b/compare.html
@@ -109,6 +109,25 @@
             </div>
           </header>
 
+          <div class="compare-metrics-grid">
+            <div class="compare-metric-tile">
+              <p class="compare-metric-label">Political stance</p>
+              <p class="compare-metric-value">To be defined</p>
+            </div>
+            <div class="compare-metric-tile">
+              <p class="compare-metric-label">Salience in domestic politics</p>
+              <p class="compare-metric-value">To be defined</p>
+            </div>
+            <div class="compare-metric-tile">
+              <p class="compare-metric-label">Alignment with EU frameworks</p>
+              <p class="compare-metric-value">To be defined</p>
+            </div>
+            <div class="compare-metric-tile">
+              <p class="compare-metric-label">Implementation capacity</p>
+              <p class="compare-metric-value">To be defined</p>
+            </div>
+          </div>
+
           <div class="compare-panel-body">
             <section class="compare-block">
               <h3><span class="compare-section-icon">🧭</span>Political climate</h3>
@@ -155,6 +174,25 @@
               </div>
             </div>
           </header>
+
+          <div class="compare-metrics-grid">
+            <div class="compare-metric-tile">
+              <p class="compare-metric-label">Political stance</p>
+              <p class="compare-metric-value">To be defined</p>
+            </div>
+            <div class="compare-metric-tile">
+              <p class="compare-metric-label">Salience in domestic politics</p>
+              <p class="compare-metric-value">To be defined</p>
+            </div>
+            <div class="compare-metric-tile">
+              <p class="compare-metric-label">Alignment with EU frameworks</p>
+              <p class="compare-metric-value">To be defined</p>
+            </div>
+            <div class="compare-metric-tile">
+              <p class="compare-metric-label">Implementation capacity</p>
+              <p class="compare-metric-value">To be defined</p>
+            </div>
+          </div>
 
           <div class="compare-panel-body">
             <section class="compare-block">


### PR DESCRIPTION
## Summary
- add metric grids beneath each compare panel header to highlight key metrics
- style the metric tiles with grid layout, card visuals, and responsive behavior

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa65362748320bf94064ac27a74f5)