### PR TITLE
Add interactive synced metric tiles to compare page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -845,31 +845,10 @@ h1, h2, h3, h4 {
   color: #6b7280;
 }
 
-.compare-meta {
-  margin-top: 0.35rem;
-}
-
 .compare-meta-line {
-  margin: 0 0 0.4rem;
+  margin: 0;
   font-size: 0.9rem;
   color: #6b7280;
-}
-
-.compare-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-}
-
-.compare-chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.18rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.04);
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: #374151;
 }
 
 /* Compare – metric tiles */
@@ -882,25 +861,82 @@ h1, h2, h3, h4 {
 }
 
 .compare-metric-tile {
-  background: #f8fafc;
   border-radius: 0.9rem;
-  padding: 0.6rem 0.8rem;
   border: 1px solid rgba(148, 163, 184, 0.5);
+  background: #f8fafc;
   box-shadow: 0 4px 10px rgba(15, 23, 42, 0.04);
+  overflow: hidden;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.08s ease;
+}
+
+.compare-metric-tile:hover {
+  border-color: #cbd5f5;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+  transform: translateY(-1px);
+}
+
+.compare-metric-trigger {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.6rem 0.8rem 0.55rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
 }
 
 .compare-metric-label {
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: #6b7280;
-  margin-bottom: 0.15rem;
+  margin: 0 0 0.2rem;
 }
 
 .compare-metric-value {
   font-size: 0.9rem;
   font-weight: 500;
   color: #111827;
+  margin: 0;
+}
+
+/* Expanded detail */
+
+.compare-metric-detail {
+  padding: 0.65rem 0.8rem 0.75rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 0.88rem;
+  line-height: 1.5;
+  background: #0f172a; /* dark mode feel */
+  color: #e5e7eb;
+}
+
+.compare-metric-detail p {
+  margin: 0 0 0.4rem;
+}
+
+.compare-metric-detail ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.compare-metric-detail li {
+  margin-bottom: 0.15rem;
+}
+
+/* tile state when expanded */
+
+.compare-metric-tile.is-expanded {
+  border-color: #1d4ed8;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.25);
+}
+
+.compare-metric-tile.is-expanded .compare-metric-label {
+  color: #bfdbfe;
+}
+
+.compare-metric-tile.is-expanded .compare-metric-value {
+  color: #e5e7eb;
 }
 
 /* Voor later: niveaus met kleurverschil */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -64,4 +64,64 @@ document.addEventListener('DOMContentLoaded', () => {
     updateLabel(selectA, labelA, 'No country selected yet', pillA);
     updateLabel(selectB, labelB, 'No country selected yet', pillB);
   }
+
+  // Compare metric tiles – synced expand/collapse between countries
+  const metricTiles = document.querySelectorAll('.compare-metric-tile');
+
+  if (metricTiles.length) {
+    const triggers = document.querySelectorAll('.compare-metric-trigger');
+
+    function setTileExpanded(tile, expanded) {
+      const detail = tile.querySelector('.compare-metric-detail');
+      const trigger = tile.querySelector('.compare-metric-trigger');
+
+      tile.classList.toggle('is-expanded', expanded);
+
+      if (detail) {
+        detail.hidden = !expanded;
+      }
+      if (trigger) {
+        trigger.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      }
+    }
+
+    function collapseAllTiles() {
+      metricTiles.forEach(tile => setTileExpanded(tile, false));
+    }
+
+    function toggleTopic(topic) {
+      const topicTiles = Array.from(metricTiles).filter(
+        tile => tile.dataset.topic === topic
+      );
+
+      if (!topicTiles.length) return;
+
+      const isCurrentlyExpanded = topicTiles.every(tile =>
+        tile.classList.contains('is-expanded')
+      );
+
+      // Eerst alles dicht
+      collapseAllTiles();
+
+      // Als het al open stond: nu gewoon alles dicht laten
+      if (isCurrentlyExpanded) {
+        return;
+      }
+
+      // Anders dit onderwerp in beide landen openen
+      topicTiles.forEach(tile => setTileExpanded(tile, true));
+    }
+
+    triggers.forEach(trigger => {
+      trigger.addEventListener('click', () => {
+        const tile = trigger.closest('.compare-metric-tile');
+        if (!tile) return;
+
+        const topic = tile.dataset.topic;
+        if (!topic) return;
+
+        toggleTopic(topic);
+      });
+    });
+  }
 });

--- a/compare.html
+++ b/compare.html
@@ -97,34 +97,87 @@
               <h2>Country A</h2>
               <p class="compare-country-label" id="compare-label-a">No country selected yet</p>
             </div>
-            <div class="compare-meta">
-              <p class="compare-meta-line">
-                Placeholder political label for Country A.
-              </p>
-              <div class="compare-chips">
-                <span class="compare-chip">TBD stance</span>
-                <span class="compare-chip">TBD salience</span>
-                <span class="compare-chip">TBD EU alignment</span>
-              </div>
-            </div>
+            <p class="compare-meta-line">
+              A short political profile will be added here once the country analysis is completed.
+            </p>
           </header>
 
           <div class="compare-metrics-grid">
-            <div class="compare-metric-tile">
-              <p class="compare-metric-label">Political stance</p>
-              <p class="compare-metric-value">To be defined</p>
+            <div class="compare-metric-tile" data-topic="stance">
+              <button class="compare-metric-trigger" type="button" aria-expanded="false">
+                <p class="compare-metric-label">Political stance</p>
+                <p class="compare-metric-value">
+                  Short summary of how restrictive, balanced or open the national migration stance is.
+                </p>
+              </button>
+              <div class="compare-metric-detail" hidden>
+                <p>
+                  This expanded section will provide a more detailed qualitative assessment of the political
+                  stance on migration in this country. It can cover party positions, recent reforms and
+                  how stable the current line appears over time.
+                </p>
+                <ul>
+                  <li>Room for descriptive text on recent government decisions.</li>
+                  <li>Optional bullet points with key developments.</li>
+                </ul>
+              </div>
             </div>
-            <div class="compare-metric-tile">
-              <p class="compare-metric-label">Salience in domestic politics</p>
-              <p class="compare-metric-value">To be defined</p>
+
+            <div class="compare-metric-tile" data-topic="salience">
+              <button class="compare-metric-trigger" type="button" aria-expanded="false">
+                <p class="compare-metric-label">Salience in domestic politics</p>
+                <p class="compare-metric-value">
+                  Concise overview of how central migration is in public debate and electoral competition.
+                </p>
+              </button>
+              <div class="compare-metric-detail" hidden>
+                <p>
+                  Here you can describe how frequently migration appears in campaigns, coalition talks and
+                  media debates, and whether this has intensified in recent years.
+                </p>
+                <ul>
+                  <li>Examples of peak politicisation moments.</li>
+                  <li>Reference to main parties framing the issue.</li>
+                </ul>
+              </div>
             </div>
-            <div class="compare-metric-tile">
-              <p class="compare-metric-label">Alignment with EU frameworks</p>
-              <p class="compare-metric-value">To be defined</p>
+
+            <div class="compare-metric-tile" data-topic="alignment">
+              <button class="compare-metric-trigger" type="button" aria-expanded="false">
+                <p class="compare-metric-label">Alignment with EU frameworks</p>
+                <p class="compare-metric-value">
+                  High-level indication of how closely national practice follows key EU instruments.
+                </p>
+              </button>
+              <div class="compare-metric-detail" hidden>
+                <p>
+                  This part can summarise how the country implements CEAS, the Pact on Migration and Asylum
+                  and other relevant EU instruments, including any derogations or opt-outs.
+                </p>
+                <ul>
+                  <li>Implementation strengths and gaps.</li>
+                  <li>Areas where national policy goes beyond EU standards.</li>
+                </ul>
+              </div>
             </div>
-            <div class="compare-metric-tile">
-              <p class="compare-metric-label">Implementation capacity</p>
-              <p class="compare-metric-value">To be defined</p>
+
+            <div class="compare-metric-tile" data-topic="capacity">
+              <button class="compare-metric-trigger" type="button" aria-expanded="false">
+                <p class="compare-metric-label">Implementation capacity</p>
+                <p class="compare-metric-value">
+                  Brief insight into administrative, financial and operational capacity to implement policy.
+                </p>
+              </button>
+              <div class="compare-metric-detail" hidden>
+                <p>
+                  This field can describe reception infrastructure, staffing, coordination across levels of
+                  government and the ability to respond to sudden inflows.
+                </p>
+                <ul>
+                  <li>Examples of bottlenecks or good practices.</li>
+                  <li>Reference to recent capacity-building reforms.</li>
+                </ul>
+              </div>
             </div>
           </div>
 
@@ -163,34 +216,87 @@
               <h2>Country B</h2>
               <p class="compare-country-label" id="compare-label-b">No country selected yet</p>
             </div>
-            <div class="compare-meta">
-              <p class="compare-meta-line">
-                Placeholder political label for Country B.
-              </p>
-              <div class="compare-chips">
-                <span class="compare-chip">TBD stance</span>
-                <span class="compare-chip">TBD salience</span>
-                <span class="compare-chip">TBD EU alignment</span>
-              </div>
-            </div>
+            <p class="compare-meta-line">
+              A short political profile will be added here once the country analysis is completed.
+            </p>
           </header>
 
           <div class="compare-metrics-grid">
-            <div class="compare-metric-tile">
-              <p class="compare-metric-label">Political stance</p>
-              <p class="compare-metric-value">To be defined</p>
+            <div class="compare-metric-tile" data-topic="stance">
+              <button class="compare-metric-trigger" type="button" aria-expanded="false">
+                <p class="compare-metric-label">Political stance</p>
+                <p class="compare-metric-value">
+                  Short summary of how restrictive, balanced or open the national migration stance is.
+                </p>
+              </button>
+              <div class="compare-metric-detail" hidden>
+                <p>
+                  This expanded section will provide a more detailed qualitative assessment of the political
+                  stance on migration in the second country. It can cover party positions, recent reforms and
+                  how stable the current line appears over time.
+                </p>
+                <ul>
+                  <li>Room for descriptive text on recent government decisions.</li>
+                  <li>Optional bullet points with key developments.</li>
+                </ul>
+              </div>
             </div>
-            <div class="compare-metric-tile">
-              <p class="compare-metric-label">Salience in domestic politics</p>
-              <p class="compare-metric-value">To be defined</p>
+
+            <div class="compare-metric-tile" data-topic="salience">
+              <button class="compare-metric-trigger" type="button" aria-expanded="false">
+                <p class="compare-metric-label">Salience in domestic politics</p>
+                <p class="compare-metric-value">
+                  Concise overview of how central migration is in public debate and electoral competition.
+                </p>
+              </button>
+              <div class="compare-metric-detail" hidden>
+                <p>
+                  Here you can describe how frequently migration appears in campaigns, coalition talks and
+                  media debates in this country, and whether this has intensified in recent years.
+                </p>
+                <ul>
+                  <li>Examples of peak politicisation moments.</li>
+                  <li>Reference to main parties framing the issue.</li>
+                </ul>
+              </div>
             </div>
-            <div class="compare-metric-tile">
-              <p class="compare-metric-label">Alignment with EU frameworks</p>
-              <p class="compare-metric-value">To be defined</p>
+
+            <div class="compare-metric-tile" data-topic="alignment">
+              <button class="compare-metric-trigger" type="button" aria-expanded="false">
+                <p class="compare-metric-label">Alignment with EU frameworks</p>
+                <p class="compare-metric-value">
+                  High-level indication of how closely national practice follows key EU instruments.
+                </p>
+              </button>
+              <div class="compare-metric-detail" hidden>
+                <p>
+                  This part can summarise how the country implements CEAS, the Pact on Migration and Asylum
+                  and other relevant EU instruments, including any derogations or opt-outs.
+                </p>
+                <ul>
+                  <li>Implementation strengths and gaps.</li>
+                  <li>Areas where national policy goes beyond EU standards.</li>
+                </ul>
+              </div>
             </div>
-            <div class="compare-metric-tile">
-              <p class="compare-metric-label">Implementation capacity</p>
-              <p class="compare-metric-value">To be defined</p>
+
+            <div class="compare-metric-tile" data-topic="capacity">
+              <button class="compare-metric-trigger" type="button" aria-expanded="false">
+                <p class="compare-metric-label">Implementation capacity</p>
+                <p class="compare-metric-value">
+                  Brief insight into administrative, financial and operational capacity to implement policy.
+                </p>
+              </button>
+              <div class="compare-metric-detail" hidden>
+                <p>
+                  This field can describe reception infrastructure, staffing, coordination across levels of
+                  government and the ability to respond to sudden inflows in this country.
+                </p>
+                <ul>
+                  <li>Examples of bottlenecks or good practices.</li>
+                  <li>Reference to recent capacity-building reforms.</li>
+                </ul>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- replace compare page tiles with expandable, data-topic linked content for both countries
- refresh tile styling with hover/expanded states and dark detail panels
- sync tile expansion across countries via new JavaScript logic and remove placeholder chips

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691faac1f15c832085524c484ab8fbf5)