### PR TITLE
Refresh buttons, Italy page, and compare layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -91,7 +91,7 @@ body {
 }
 
 body.compare-page {
-  background: var(--cmp-page-bg);
+  background: #0f172a;
   color: var(--cmp-card-text);
 }
 
@@ -119,36 +119,38 @@ a {
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
-  padding: 0.85rem 1.15rem;
-  font-weight: 700;
+  padding: 0.9rem 1.8rem;
+  font-weight: 600;
   text-decoration: none;
-  border-radius: 12px;
-  border: 1px solid transparent;
-  transition: background-color var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast),
-    transform var(--transition-fast);
+  border-radius: 999px;
+  border: none;
+  transition: background-color 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
 
-.btn-primary {
-  background: var(--eu-gold);
-  color: #0a1120;
-  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.18);
+.btn-primary,
+.hero-actions .btn-primary {
+  background-color: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.35);
 }
 
-.btn-primary:hover {
+.btn-primary:hover,
+.hero-actions .btn-primary:hover {
+  background-color: #1d4ed8;
   transform: translateY(-1px);
-  background: #ffdb4d;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.4);
 }
 
 .btn-secondary {
-  background: transparent;
-  color: var(--text-invert);
-  border-color: rgba(255, 255, 255, 0.55);
+  background: #e5e7eb;
+  color: #0f172a;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
 }
 
 .btn-secondary:hover {
   transform: translateY(-1px);
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.75);
+  background: #d1d5db;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
 }
 
 /* ========================================
@@ -166,6 +168,51 @@ a {
 
 .site-main {
   padding: 0 0 3rem;
+}
+
+.page-main {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+}
+
+.page-intro h1 {
+  font-size: 2.3rem;
+  margin-bottom: 0.75rem;
+}
+
+.page-intro p {
+  max-width: 52rem;
+  color: #4b5563;
+}
+
+.country-section-list {
+  margin-top: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.country-section-card {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 1.75rem 2rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+}
+
+.country-section-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: #e5edff;
+  color: #1d4ed8;
+  margin-bottom: 0.9rem;
 }
 
 .site-main h1 {
@@ -522,18 +569,18 @@ a {
 }
 
 .compare-page .section-light {
-  background: var(--cmp-page-bg);
+  background: transparent;
   border: none;
-  color: var(--cmp-card-text);
+  color: #e5e7eb;
 }
 
-.compare-page .section-light p {
-  color: var(--cmp-card-muted);
-}
-
-.compare-page .section-header h1,
+.compare-page .section-light p,
 .compare-page .section-header p {
-  color: var(--cmp-card-text);
+  color: #cbd5e1;
+}
+
+.compare-page .section-header h1 {
+  color: #f8fafc;
 }
 
 .compare-page .country-select-header,
@@ -553,7 +600,7 @@ a {
 
 .compare-page .panel-intro {
   margin: 0 0 1.2rem;
-  color: var(--cmp-card-muted);
+  color: #cbd5e1;
   font-size: 0.95rem;
 }
 
@@ -597,130 +644,76 @@ a {
   box-shadow: 0 0 0 1px #4f46e522, 0 6px 16px rgba(0, 0, 0, 0.14);
 }
 
-.compare-page .compare-grid {
-  max-width: 1180px;
-  margin: 2.5rem auto 3.5rem;
+.compare-page {
+  background: #0b1220;
+}
+
+.main-content {
+  background: #0f172a;
+}
+
+.comparison-panels {
+  max-width: 1150px;
+  margin: 2.5rem auto 4rem;
+  padding: 0 1.5rem;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 2rem;
 }
 
-.compare-page .compare-panel {
-  background: var(--cmp-panel-inner-bg);
-  border-radius: 22px;
-  padding: 1.8rem 1.8rem 2.2rem;
-  box-shadow: var(--cmp-shadow-panel);
-  border: 1px solid var(--cmp-border-subtle);
-  display: flex;
-  flex-direction: column;
-  gap: 1.3rem;
-}
-
-.compare-page .compare-panel h2,
-.compare-page .compare-panel h3,
-.compare-page .compare-panel h4,
-.compare-page .compare-panel label {
+.comparison-panel {
+  background: #020617;
+  border-radius: 1.8rem;
+  padding: 1.9rem 1.8rem 2.2rem;
+  box-shadow: 0 22px 55px rgba(15, 23, 42, 0.5);
   color: #e5e7eb;
 }
 
-.compare-page .metric-grid {
+.comparison-panel h2,
+.comparison-panel label {
+  color: #f8fafc;
+}
+
+.comparison-panel-metrics {
+  margin-top: 1.75rem;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1.2rem;
+  gap: 1.3rem;
 }
 
-.compare-page .metric-card,
-.compare-page .metric-tile {
-  background: var(--cmp-card-bg);
-  color: var(--cmp-card-text);
-  border-radius: 18px;
-  padding: 1rem 1.2rem;
-  border: 1px solid rgba(148, 163, 184, 0.45);
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
-  transition:
-    background-color 0.18s ease,
-    box-shadow 0.18s ease,
-    transform 0.18s ease,
-    border-color 0.18s ease;
-  display: grid;
-  grid-template-rows: auto 1fr;
-  align-items: start;
-  gap: 0.6rem;
-  min-height: 180px;
-  position: relative;
-  overflow: hidden;
+.compare-page .metric-card {
+  background: #f9fafb;
+  border-radius: 1.25rem;
+  padding: 1.25rem 1.4rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.18);
+  transition: box-shadow 0.18s ease, transform 0.18s ease, background-color 0.18s ease;
+  grid-column: span 1;
 }
 
-.compare-page .metric-title {
-  font-size: 0.82rem;
-  letter-spacing: 0.09em;
+.compare-page .metric-card h3 {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  margin-bottom: 0.45rem;
   color: #111827;
+  margin-bottom: 0.5rem;
 }
 
-.compare-page .metric-summary,
-.compare-page .metric-expanded {
+.compare-page .metric-card p {
   font-size: 0.9rem;
   line-height: 1.5;
-  color: var(--cmp-card-muted);
-  grid-row: 2;
-  transition: opacity var(--transition-fast);
+  color: #4b5563;
+  column-count: 1;
 }
 
-.compare-page .metric-expanded {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.compare-page .metric-card:hover,
-.compare-page .metric-tile:hover {
-  background: #eef2ff;
-  border-color: rgba(129, 140, 248, 0.6);
-  box-shadow: var(--cmp-shadow-card);
+.compare-page .metric-card.expanded {
+  grid-column: span 2;
+  background-color: #e5edff;
   transform: translateY(-2px);
-}
-
-.compare-page .metric-card.metric-card--expanded,
-.compare-page .metric-tile.metric-card--expanded,
-.compare-page .metric-tile.is-expanded {
-  background: var(--cmp-card-expanded-bg);
-  border-color: rgba(79, 70, 229, 0.6);
-}
-
-.compare-page .metric-tile.is-expanded .metric-expanded,
-.compare-page .metric-card.metric-card--expanded .metric-expanded {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.compare-page .metric-card.metric-card--expanded .metric-summary,
-.compare-page .metric-tile.is-expanded .metric-summary {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.compare-page .metric-tile.is-expanded .metric-title,
-.compare-page .metric-tile.is-expanded .metric-summary,
-.compare-page .metric-card.metric-card--expanded .metric-title,
-.compare-page .metric-card.metric-card--expanded .metric-summary {
-  color: var(--cmp-card-text);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.25);
 }
 
 @media (max-width: 900px) {
-  .compare-page .compare-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 768px) {
-  .compare-page .metric-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 640px) {
-  .compare-page .metric-grid {
+  .comparison-panels {
     grid-template-columns: 1fr;
   }
 }

--- a/compare.html
+++ b/compare.html
@@ -30,7 +30,7 @@
     </div>
   </header>
 
-<main class="site-main">
+<main class="site-main main-content">
   <section class="section section-light">
     <div class="container">
       <header class="section-header">
@@ -41,8 +41,8 @@
         </p>
       </header>
 
-      <div class="compare-grid compare-panels">
-        <article class="compare-panel compare-panel-a">
+      <div class="comparison-panels">
+        <article class="comparison-panel compare-panel-a">
           <div class="country-select-header">
             <label for="compare-country-a">Select country</label>
             <select class="country-select" id="compare-country-a" data-side="A" name="countryA">
@@ -55,50 +55,38 @@
 
           <p class="panel-intro">No country selected yet. Choose one to view its profile highlights.</p>
 
-          <div class="metric-grid">
-            <div class="metric-tile metric-card" data-metric="stance">
-              <div class="metric-title">POLITICAL STANCE</div>
-              <div class="metric-summary">
+          <div class="comparison-panel-metrics">
+            <div class="metric-card" data-metric="stance">
+              <h3>Political stance</h3>
+              <p>
                 The country's current migration stance leans toward balanced cooperation, blending national security considerations with humanitarian obligations. Narrative shifts over election cycles keep the debate active and nuanced within cabinet discussions.
-              </div>
-              <div class="metric-expanded">
-                Longer analysis describing coalition tensions, parliamentary votes, and regional perspectives on migration. Details highlight how rhetoric aligns with policy delivery and where compromises emerge across parties.
-              </div>
+              </p>
             </div>
 
-            <div class="metric-tile metric-card" data-metric="salience">
-              <div class="metric-title">SALIENCE IN DOMESTIC POLITICS</div>
-              <div class="metric-summary">
+            <div class="metric-card" data-metric="salience">
+              <h3>Salience in domestic politics</h3>
+              <p>
                 Migration regularly features in talk shows, parliamentary questions, and civic forums. Peaks occur around border incidents or labour market reforms, prompting rapid responses from leading parties and media commentators.
-              </div>
-              <div class="metric-expanded">
-                Expanded narrative on election-season framing, public opinion shifts, and the role of local elections in elevating migration. Notes how agenda-setting actors influence the tempo of national debate.
-              </div>
+              </p>
             </div>
 
-            <div class="metric-tile metric-card" data-metric="eu-alignment">
-              <div class="metric-title">EU ALIGNMENT</div>
-              <div class="metric-summary">
+            <div class="metric-card" data-metric="eu-alignment">
+              <h3>EU alignment</h3>
+              <p>
                 Implementation of EU migration and asylum rules generally tracks common standards, with ongoing adjustments to meet new pact obligations. Cooperation with agencies remains steady, supported by technical assistance.
-              </div>
-              <div class="metric-expanded">
-                Additional context on transposition timelines, temporary derogations, and collaborative pilots with EU partners. Notes where national provisions exceed or diverge from agreed frameworks.
-              </div>
+              </p>
             </div>
 
-            <div class="metric-tile metric-card" data-metric="capacity">
-              <div class="metric-title">IMPLEMENTATION CAPACITY</div>
-              <div class="metric-summary">
+            <div class="metric-card" data-metric="capacity">
+              <h3>Implementation capacity</h3>
+              <p>
                 Administrative structures coordinate across ministries and regional authorities, with dedicated budgets for reception and integration. Workforce planning and digital tools are being scaled to manage fluctuating arrivals.
-              </div>
-              <div class="metric-expanded">
-                Further explanation of staffing models, contingency planning, and procurement pipelines. Highlights training initiatives and data-sharing protocols that underpin day-to-day operations.
-              </div>
+              </p>
             </div>
           </div>
         </article>
 
-        <article class="compare-panel compare-panel-b">
+        <article class="comparison-panel compare-panel-b">
           <div class="country-select-header">
             <label for="compare-country-b">Select country</label>
             <select class="country-select" id="compare-country-b" data-side="B" name="countryB">
@@ -111,45 +99,33 @@
 
           <p class="panel-intro">No country selected yet. Choose one to view its profile highlights.</p>
 
-          <div class="metric-grid">
-            <div class="metric-tile metric-card" data-metric="stance">
-              <div class="metric-title">POLITICAL STANCE</div>
-              <div class="metric-summary">
+          <div class="comparison-panel-metrics">
+            <div class="metric-card" data-metric="stance">
+              <h3>Political stance</h3>
+              <p>
                 The government frames migration through stability and partnership, balancing border management with international protection duties. Statements from key ministers emphasise predictability and cooperation with neighbouring states.
-              </div>
-              <div class="metric-expanded">
-                Detailed look at party manifestos, coalition agreements, and administrative circulars guiding implementation. Reviews the durability of current commitments amid shifting regional dynamics.
-              </div>
+              </p>
             </div>
 
-            <div class="metric-tile metric-card" data-metric="salience">
-              <div class="metric-title">SALIENCE IN DOMESTIC POLITICS</div>
-              <div class="metric-summary">
-                Media coverage intensifies around legislative updates and migration-related court rulings. Civil society forums and academic reports feed into televised debates that shape voter perceptions throughout the year.
-              </div>
-              <div class="metric-expanded">
-                Longer analysis of issue cycles, including election debates and regional referenda that amplify attention. Explores how opposition narratives influence agenda-setting and policy revisions.
-              </div>
+            <div class="metric-card" data-metric="salience">
+              <h3>Salience in domestic politics</h3>
+              <p>
+                Media coverage intensifies around legislative updates and migration-related court rulings. Civil society forumsand academic reports feed into televised debates that shape voter perceptions throughout the year.
+              </p>
             </div>
 
-            <div class="metric-tile metric-card" data-metric="eu-alignment">
-              <div class="metric-title">EU ALIGNMENT</div>
-              <div class="metric-summary">
+            <div class="metric-card" data-metric="eu-alignment">
+              <h3>EU alignment</h3>
+              <p>
                 Compliance with EU frameworks is actively managed through inter-ministerial taskforces. Pilot projects with EU agencies test new screening approaches and improve interoperability with partner systems.
-              </div>
-              <div class="metric-expanded">
-                Additional insight into legislative transposition, information-sharing standards, and contingency clauses. Notes coordination with neighbouring states on return and reception efforts.
-              </div>
+              </p>
             </div>
 
-            <div class="metric-tile metric-card" data-metric="capacity">
-              <div class="metric-title">IMPLEMENTATION CAPACITY</div>
-              <div class="metric-summary">
+            <div class="metric-card" data-metric="capacity">
+              <h3>Implementation capacity</h3>
+              <p>
                 Reception networks leverage municipal facilities and partnerships with NGOs. Investment in digital case management aims to streamline procedures and reduce processing backlogs during peak periods.
-              </div>
-              <div class="metric-expanded">
-                Expanded description of budget allocations, training cycles, and surge mechanisms. Notes how logistics hubs and data systems support rapid scaling when migration patterns shift suddenly.
-              </div>
+              </p>
             </div>
           </div>
         </article>
@@ -171,5 +147,31 @@
   </footer>
 
   <script src="assets/js/main.js"></script>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const cardsByMetric = {};
+
+      document.querySelectorAll('.metric-card').forEach(card => {
+        const metric = card.dataset.metric;
+        if (!metric) return;
+
+        if (!cardsByMetric[metric]) cardsByMetric[metric] = [];
+        cardsByMetric[metric].push(card);
+
+        card.addEventListener('mouseenter', () => {
+          Object.values(cardsByMetric).forEach(group =>
+            group.forEach(c => c.classList.remove('expanded'))
+          );
+
+          cardsByMetric[metric].forEach(c => c.classList.add('expanded'));
+        });
+
+        card.addEventListener('mouseleave', () => {
+          cardsByMetric[metric].forEach(c => c.classList.remove('expanded'));
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/countries/italy.html
+++ b/countries/italy.html
@@ -27,65 +27,47 @@
     </div>
   </header>
 
-  <main class="site-main">
-
-    <!-- Header + intro -->
-    <section class="container country-header">
-      <p class="country-eyebrow">Country profile</p>
+  <main class="page-main">
+    <section class="page-intro">
       <h1>Italy</h1>
-      <p class="country-intro">
-        Key entry point on the Central Mediterranean route, with migration at the
-        centre of domestic politics and EU debates on responsibility-sharing.
+      <p>
+        Key entry point on the Central Mediterranean route, with migration at the centre of domestic politics and EU debates on responsibility-sharing.
       </p>
     </section>
 
-    <!-- PREMIUM CARDS -->
-    <section class="section">
-      <div class="container country-layout">
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Short summary of the current government, coalitions, main parties and how migration features in political discourse.
+        </p>
+      </article>
 
-        <!-- CARD 1 -->
-        <article class="card">
-          <span class="card-tag">PC</span>
-          <h2 class="card-title">Political climate</h2>
-          <p>
-            Short summary of the current government, coalitions, main parties and
-            how migration features in political discourse.
-          </p>
-        </article>
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Key figures on arrivals, asylum applications, recognitions and return, plus routes that are particularly relevant for the country.
+        </p>
+      </article>
 
-        <!-- CARD 2 -->
-        <article class="card">
-          <span class="card-tag">MS</span>
-          <h2 class="card-title">Migration statistics</h2>
-          <p>
-            Key figures on arrivals, asylum applications, recognitions and return,
-            plus routes that are particularly relevant for the country.
-          </p>
-        </article>
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Key national policies, recent reforms, external border control and cooperation with EU agencies or third countries.
+        </p>
+      </article>
 
-        <!-- CARD 3 -->
-        <article class="card">
-          <span class="card-tag">CP</span>
-          <h2 class="card-title">Current policies</h2>
-          <p>
-            Key national policies, recent reforms, external border control and
-            cooperation with EU agencies or third countries.
-          </p>
-        </article>
-
-        <!-- CARD 4 -->
-        <article class="card">
-          <span class="card-tag">AP</span>
-          <h2 class="card-title">Application possibilities</h2>
-          <p>
-            Organisation of reception systems, integration measures and challenges
-            at local and regional level.
-          </p>
-        </article>
-
-      </div>
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Organisation of reception systems, integration measures and challenges at local and regional level.
+        </p>
+      </article>
     </section>
-
   </main>
 
   <footer class="site-footer">


### PR DESCRIPTION
## Summary
- update primary and secondary button styles to blue, pill-shaped CTAs
- restyle the Italy country page with the shared page layout and section cards
- refresh the compare page grid and interactions so metric cards expand across both panels

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fc0d07adc8320b7455092c47620a7)