### PR TITLE
Fix compare panel card layout and hover

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -667,6 +667,7 @@ a {
   padding: 1.9rem 1.8rem 2.2rem;
   box-shadow: 0 22px 55px rgba(15, 23, 42, 0.5);
   color: #e5e7eb;
+  overflow: hidden;
 }
 
 .comparison-panel h2,
@@ -674,19 +675,32 @@ a {
   color: #f8fafc;
 }
 
+
 .comparison-panel-metrics {
   margin-top: 1.75rem;
+}
+
+.comparison-panel-metrics,
+.card-container {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1.3rem;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  align-items: stretch;
+}
+
+.compare-page .metric-card,
+.compare-card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.18);
+  transition: all 0.25s ease;
 }
 
 .compare-page .metric-card {
-  background: #f9fafb;
-  border-radius: 1.25rem;
-  padding: 1.25rem 1.4rem;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.18);
-  transition: box-shadow 0.18s ease, transform 0.18s ease, background-color 0.18s ease;
   grid-column: span 1;
 }
 
@@ -705,11 +719,17 @@ a {
   column-count: 1;
 }
 
+.compare-page .metric-card:hover,
+.compare-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}
+
 .compare-page .metric-card.expanded {
   grid-column: span 2;
   background-color: #e5edff;
-  transform: translateY(-2px);
-  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.25);
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.25);
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- convert compare panel card container to a two-column grid with stretched items for uniform layout
- update compare cards to fill available height and use a vertical lift hover effect instead of scaling
- retain overflow clipping on comparison panels to preserve rounded corners while hovering

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fc3aa011c8320a17042bed6fb281c)