### PR TITLE
Standardize compare panel card layout and hover state

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -683,21 +683,22 @@ a {
 .comparison-panel-metrics,
 .card-container {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
   gap: 1.5rem;
   align-items: stretch;
 }
 
 .compare-page .metric-card,
 .compare-card {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  background: #ffffff;
+  background-color: #ffffff;
   border-radius: 16px;
   padding: 1.5rem;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.18);
-  transition: all 0.25s ease;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  transition: box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 .compare-page .metric-card {
@@ -721,8 +722,12 @@ a {
 
 .compare-page .metric-card:hover,
 .compare-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  background-color: #f3f6ff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+
+.compare-card p {
+  column-count: 1;
 }
 
 .compare-page .metric-card.expanded {


### PR DESCRIPTION
## Summary
- switch compare panel card container to a uniform 2x2 grid with equal-height rows
- normalize compare card styling and hover effects without transforms
- enforce single-column text inside compare cards

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fc574297883208536adc7259260c1)