### PR TITLE
Ensure compare cards have consistent height and remove hover

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -693,10 +693,10 @@ a {
 .compare-card {
   background-color: #ffffff;
   border-radius: 16px;
-  padding: 1.5rem;
+  padding: 1.6rem;
   display: flex;
   flex-direction: column;
-  height: 100%;
+  min-height: 260px;
   box-shadow: 0 0 0 rgba(0, 0, 0, 0);
   transition: box-shadow 0.2s ease, background-color 0.2s ease;
 }
@@ -718,11 +718,6 @@ a {
   line-height: 1.5;
   color: #4b5563;
   column-count: 1;
-}
-
-.compare-card:hover {
-  background-color: #f3f6ff;
-  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.18);
 }
 
 .compare-page .metric-card:hover {


### PR DESCRIPTION
## Summary
- set compare cards to a consistent minimum height for uniform appearance
- remove hover styling from compare cards to prevent glitches
- slightly adjust card padding to match layout spacing

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fca331fdc832094fbd50bfb023789)