### PR TITLE
Refine compare panel card layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -676,11 +676,12 @@ a {
 }
 
 
+
 .comparison-panel-metrics {
   margin-top: 1.75rem;
 }
 
-.comparison-panel-metrics,
+.compare-card-grid,
 .card-container {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -689,16 +690,15 @@ a {
   align-items: stretch;
 }
 
-.compare-page .metric-card,
 .compare-card {
   background-color: #ffffff;
   border-radius: 16px;
   padding: 1.6rem;
   display: flex;
   flex-direction: column;
-  min-height: 260px;
+  height: 100%;
   box-shadow: 0 0 0 rgba(0, 0, 0, 0);
-  transition: box-shadow 0.2s ease, background-color 0.2s ease;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .compare-page .metric-card {
@@ -720,7 +720,7 @@ a {
   column-count: 1;
 }
 
-.compare-page .metric-card:hover {
+.compare-card:hover {
   background-color: #f3f6ff;
   box-shadow: 0 10px 26px rgba(0, 0, 0, 0.18);
 }

--- a/compare.html
+++ b/compare.html
@@ -56,32 +56,34 @@
           <p class="panel-intro">No country selected yet. Choose one to view its profile highlights.</p>
 
           <div class="comparison-panel-metrics">
-            <div class="metric-card" data-metric="stance">
-              <h3>Political stance</h3>
-              <p>
-                The country's current migration stance leans toward balanced cooperation, blending national security considerations with humanitarian obligations. Narrative shifts over election cycles keep the debate active and nuanced within cabinet discussions.
-              </p>
-            </div>
+            <div class="compare-card-grid">
+              <div class="metric-card compare-card" data-metric="stance">
+                <h3>Political stance</h3>
+                <p>
+                  The country's current migration stance leans toward balanced cooperation, blending national security considerations with humanitarian obligations. Narrative shifts over election cycles keep the debate active and nuanced within cabinet discussions.
+                </p>
+              </div>
 
-            <div class="metric-card" data-metric="salience">
-              <h3>Salience in domestic politics</h3>
-              <p>
-                Migration regularly features in talk shows, parliamentary questions, and civic forums. Peaks occur around border incidents or labour market reforms, prompting rapid responses from leading parties and media commentators.
-              </p>
-            </div>
+              <div class="metric-card compare-card" data-metric="salience">
+                <h3>Salience in domestic politics</h3>
+                <p>
+                  Migration regularly features in talk shows, parliamentary questions, and civic forums. Peaks occur around border incidents or labour market reforms, prompting rapid responses from leading parties and media commentators.
+                </p>
+              </div>
 
-            <div class="metric-card" data-metric="eu-alignment">
-              <h3>EU alignment</h3>
-              <p>
-                Implementation of EU migration and asylum rules generally tracks common standards, with ongoing adjustments to meet new pact obligations. Cooperation with agencies remains steady, supported by technical assistance.
-              </p>
-            </div>
+              <div class="metric-card compare-card" data-metric="eu-alignment">
+                <h3>EU alignment</h3>
+                <p>
+                  Implementation of EU migration and asylum rules generally tracks common standards, with ongoing adjustments to meet new pact obligations. Cooperation with agencies remains steady, supported by technical assistance.
+                </p>
+              </div>
 
-            <div class="metric-card" data-metric="capacity">
-              <h3>Implementation capacity</h3>
-              <p>
-                Administrative structures coordinate across ministries and regional authorities, with dedicated budgets for reception and integration. Workforce planning and digital tools are being scaled to manage fluctuating arrivals.
-              </p>
+              <div class="metric-card compare-card" data-metric="capacity">
+                <h3>Implementation capacity</h3>
+                <p>
+                  Administrative structures coordinate across ministries and regional authorities, with dedicated budgets for reception and integration. Workforce planning and digital tools are being scaled to manage fluctuating arrivals.
+                </p>
+              </div>
             </div>
           </div>
         </article>
@@ -100,32 +102,34 @@
           <p class="panel-intro">No country selected yet. Choose one to view its profile highlights.</p>
 
           <div class="comparison-panel-metrics">
-            <div class="metric-card" data-metric="stance">
-              <h3>Political stance</h3>
-              <p>
-                The government frames migration through stability and partnership, balancing border management with international protection duties. Statements from key ministers emphasise predictability and cooperation with neighbouring states.
-              </p>
-            </div>
+            <div class="compare-card-grid">
+              <div class="metric-card compare-card" data-metric="stance">
+                <h3>Political stance</h3>
+                <p>
+                  The government frames migration through stability and partnership, balancing border management with international protection duties. Statements from key ministers emphasise predictability and cooperation with neighbouring states.
+                </p>
+              </div>
 
-            <div class="metric-card" data-metric="salience">
-              <h3>Salience in domestic politics</h3>
-              <p>
-                Media coverage intensifies around legislative updates and migration-related court rulings. Civil society forumsand academic reports feed into televised debates that shape voter perceptions throughout the year.
-              </p>
-            </div>
+              <div class="metric-card compare-card" data-metric="salience">
+                <h3>Salience in domestic politics</h3>
+                <p>
+                  Media coverage intensifies around legislative updates and migration-related court rulings. Civil society forumsand academic reports feed into televised debates that shape voter perceptions throughout the year.
+                </p>
+              </div>
 
-            <div class="metric-card" data-metric="eu-alignment">
-              <h3>EU alignment</h3>
-              <p>
-                Compliance with EU frameworks is actively managed through inter-ministerial taskforces. Pilot projects with EU agencies test new screening approaches and improve interoperability with partner systems.
-              </p>
-            </div>
+              <div class="metric-card compare-card" data-metric="eu-alignment">
+                <h3>EU alignment</h3>
+                <p>
+                  Compliance with EU frameworks is actively managed through inter-ministerial taskforces. Pilot projects with EU agencies test new screening approaches and improve interoperability with partner systems.
+                </p>
+              </div>
 
-            <div class="metric-card" data-metric="capacity">
-              <h3>Implementation capacity</h3>
-              <p>
-                Reception networks leverage municipal facilities and partnerships with NGOs. Investment in digital case management aims to streamline procedures and reduce processing backlogs during peak periods.
-              </p>
+              <div class="metric-card compare-card" data-metric="capacity">
+                <h3>Implementation capacity</h3>
+                <p>
+                  Reception networks leverage municipal facilities and partnerships with NGOs. Investment in digital case management aims to streamline procedures and reduce processing backlogs during peak periods.
+                </p>
+              </div>
             </div>
           </div>
         </article>


### PR DESCRIPTION
## Summary
- wrap each set of comparison cards in a dedicated grid container and tag cards with the shared class
- normalize compare card styling for equal-height grid rows and simplified hover effect
- add grid styling utility for the new wrapper and keep paragraph columns single-width

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fcb4e03d08320b3ca832a566c6ba9)