### PR TITLE
Standardize compare card layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -671,6 +671,10 @@ a {
 
 .compare-panel {
   position: relative;
+  background-color: #050b1e;
+  border-radius: 24px;
+  padding: 2.4rem 2rem;
+  margin-top: 2rem;
   overflow: visible;
 }
 
@@ -685,7 +689,14 @@ a {
   margin-top: 1.75rem;
 }
 
-.compare-card-grid,
+.compare-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
+  gap: 1.6rem;
+  align-items: stretch;
+}
+
 .card-container {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -700,12 +711,18 @@ a {
   padding: 1.6rem;
   display: flex;
   flex-direction: column;
-  min-height: 260px;
   height: 100%;
   box-shadow: 0 0 0 rgba(0, 0, 0, 0);
   position: relative;
   z-index: 1;
   transition: transform 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease;
+}
+
+.compare-card:hover {
+  transform: scale(1.05);
+  z-index: 10; /* float above neighbours */
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  background-color: #f5f7ff;
 }
 
 .compare-page .metric-card {
@@ -838,17 +855,3 @@ a {
 }
 }
 
-/* Hover overlay for compare cards */
-.compare-card {
-  position: relative;
-  z-index: 1;
-  transition: transform 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease;
-  transform-origin: center center;
-}
-
-.compare-card:hover {
-  transform: scale(1.05);
-  z-index: 10; /* float above other cards */
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
-  background-color: #f5f7ff; /* subtle highlight */
-}


### PR DESCRIPTION
## Summary
- standardize compare panel container spacing and rounding while keeping hover overlay visible
- unify compare card grid and card styling for consistent equal-height layout
- restore hover scale effect with raised z-index and refreshed highlight styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692021ec16648320a1e3fd742eb696b0)