### PR TITLE
Improve compare panel card layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -694,18 +694,11 @@ a {
   margin-top: 1.75rem;
 }
 
-.compare-card-grid {
+.compare-panel-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1.6rem;
-  align-items: flex-start;
-}
-
-.card-container {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1.6rem;
-  align-items: flex-start;
+  grid-auto-rows: 1fr;
+  gap: 1.75rem;
 }
 
 .compare-card {
@@ -715,22 +708,19 @@ a {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  min-height: 260px;
-  height: auto;
+  height: 100%;
   box-sizing: border-box;
   box-shadow: 0 0 0 rgba(0, 0, 0, 0);
   position: relative;
-  z-index: 1;
-  transition: transform 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease;
+  z-index: 0;
+  transition: transform 0.18s ease-out, box-shadow 0.18s ease-out;
 }
 
 .compare-card:hover,
 .compare-card.cmp-expanded {
-  position: relative;
-  z-index: 10; /* kaart komt naar voren */
-  transform: scale(1.03);
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.35);
-  background-color: #f5f7ff;
+  transform: translateY(-4px);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25);
+  z-index: 1;
 }
 
 .compare-page .metric-card {
@@ -755,6 +745,12 @@ a {
 
 .compare-card p {
   column-count: 1;
+}
+
+@media (max-width: 768px) {
+  .compare-panel-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 900px) {

--- a/compare.html
+++ b/compare.html
@@ -56,7 +56,7 @@
           <p class="panel-intro">No country selected yet. Choose one to view its profile highlights.</p>
 
           <div class="comparison-panel-metrics">
-            <div class="compare-card-grid">
+            <div class="compare-panel-grid">
               <div class="metric-card compare-card" data-metric="stance">
                 <h3>Political stance</h3>
                 <p>
@@ -102,7 +102,7 @@
           <p class="panel-intro">No country selected yet. Choose one to view its profile highlights.</p>
 
           <div class="comparison-panel-metrics">
-            <div class="compare-card-grid">
+            <div class="compare-panel-grid">
               <div class="metric-card compare-card" data-metric="stance">
                 <h3>Political stance</h3>
                 <p>


### PR DESCRIPTION
## Summary
- wrap compare cards in a dedicated grid container for each panel
- update styling to use CSS grid with equal-height cards and hover lift without layout shifts
- add responsive single-column layout for small screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692027a547988320bab84261a0051131)