### PR TITLE
Expand compare cards and sync panel interactions

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -701,45 +701,51 @@ a {
   gap: 1.75rem;
 }
 
-/* basis: alle kaarten even hoog, samenvatting zichtbaar */
+/* basis: alle kaarten groter en even hoog */
 .compare-card {
   background-color: var(--cmp-card-bg);
-  border-radius: 16px;
-  padding: 1.6rem;
+  border-radius: 20px;
+  padding: 1.8rem;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  min-height: 230px;          /* gelijke hoogte in rust */
-  max-height: 230px;
+
+  /* grotere basis-hoogte */
+  min-height: 320px;
+  max-height: 320px;
+
+  overflow: hidden;
   box-sizing: border-box;
-  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  box-shadow: 0 0 0 rgba(0,0,0,0);
   position: relative;
   z-index: 0;
-  overflow: hidden;           /* extra tekst verbergen in samenvattingsstaat */
-  transform-origin: center top;
+
+  transform-origin: top center;
   transition:
-    transform 0.22s ease-out,
-    box-shadow 0.22s ease-out,
-    background-color 0.22s ease-out;
+    transform 0.25s ease,
+    box-shadow 0.25s ease,
+    background-color 0.25s ease;
 }
 
-/* lichte hover, nog binnen eigen kolom */
+/* subtiel hover-effect */
 .compare-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 16px 32px rgba(0,0,0,0.35);
 }
 
-/* uitgeklapte staat: hele paneelbreedte + alle tekst zichtbaar */
+/* uitgeklapte staat: beide panelen tonen volledige tekst */
 .compare-card.cmp-expanded {
-  grid-column: 1 / -1;                /* volledige breedte paneel */
+  grid-column: 1 / -1;
   min-height: auto;
-  max-height: none;                   /* hoogte niet meer begrenzen */
+  max-height: none;
   overflow: visible;
-  padding: 2rem 2rem 2.1rem;
+
+  padding: 2.2rem 2rem 2.5rem;
   background-color: var(--cmp-card-expanded-bg);
-  transform: translateY(-4px);
-  box-shadow: 0 26px 52px rgba(0, 0, 0, 0.5);
-  z-index: 3;
+
+  transform: translateY(-6px);
+  box-shadow: 0 28px 50px rgba(0,0,0,0.55);
+  z-index: 5;
 }
 
 .compare-page .metric-card {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -101,36 +101,50 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  // Compare cards – expandable tiles
-  const compareCards = document.querySelectorAll('.compare-card');
+  // Compare cards – synced expand across both panels
+  const cards = document.querySelectorAll('.compare-card');
 
-  if (compareCards.length) {
-    const prefersHover = window.matchMedia('(hover: hover)');
+  if (cards.length) {
+    const groups = {};
+
+    // groepeer per metric
+    cards.forEach(card => {
+      const metric = card.dataset.metric;
+      if (!groups[metric]) groups[metric] = [];
+      groups[metric].push(card);
+    });
+
+    const prefersHover = window.matchMedia('(hover: hover)').matches;
     const isMobile = window.innerWidth < 768;
 
-    if (!isMobile && prefersHover.matches) {
-      // Desktop hover expand
-      compareCards.forEach(card => {
-        card.addEventListener('mouseenter', () => {
-          card.classList.add('cmp-expanded');
-        });
-        card.addEventListener('mouseleave', () => {
-          card.classList.remove('cmp-expanded');
-        });
-      });
-    } else {
-      // Mobile click expand
-      compareCards.forEach(card => {
+    function expandGroup(metric) {
+      Object.values(groups).forEach(group =>
+        group.forEach(c => c.classList.remove('cmp-expanded'))
+      );
+      groups[metric].forEach(c => c.classList.add('cmp-expanded'));
+    }
+
+    function collapseGroup(metric) {
+      groups[metric].forEach(c => c.classList.remove('cmp-expanded'));
+    }
+
+    cards.forEach(card => {
+      const metric = card.dataset.metric;
+
+      if (!isMobile && prefersHover) {
+        // Desktop hover
+        card.addEventListener('mouseenter', () => expandGroup(metric));
+        card.addEventListener('mouseleave', () => collapseGroup(metric));
+      } else {
+        // Mobile click
         card.addEventListener('click', () => {
           const already = card.classList.contains('cmp-expanded');
-
-          compareCards.forEach(c => c.classList.remove('cmp-expanded'));
-
-          if (!already) {
-            card.classList.add('cmp-expanded');
-          }
+          Object.values(groups).forEach(g =>
+            g.forEach(c => c.classList.remove('cmp-expanded'))
+          );
+          if (!already) expandGroup(metric);
         });
-      });
-    }
+      }
+    });
   }
 });


### PR DESCRIPTION
## Summary
- increase default compare card dimensions and update expanded styling
- synchronize compare card expansion across panels by shared metric

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692099b32ec883209e93596e57008011)