### PR TITLE
Add Italian flag accent to Italy page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -186,6 +186,29 @@ a {
   color: #4b5563;
 }
 
+.country-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin-bottom: 0.75rem;
+}
+
+.country-title h1 {
+  margin: 0;
+}
+
+.country-flag {
+  width: 42px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.12);
+}
+
+.flag-italy {
+  background: linear-gradient(90deg, #009246 0%, #009246 33.33%, #ffffff 33.33%, #ffffff 66.66%, #ce2b37 66.66%, #ce2b37 100%);
+}
+
 .country-section-list {
   margin-top: 2.5rem;
   display: flex;

--- a/countries/italy.html
+++ b/countries/italy.html
@@ -27,13 +27,16 @@
     </div>
   </header>
 
-  <main class="page-main">
-    <section class="page-intro">
-      <h1>Italy</h1>
-      <p>
-        Key entry point on the Central Mediterranean route, with migration at the centre of domestic politics and EU debates on responsibility-sharing.
-      </p>
-    </section>
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-italy" role="img" aria-label="Flag of Italy"></span>
+          <h1>Italy</h1>
+        </div>
+        <p>
+          Key entry point on the Central Mediterranean route, with migration at the centre of domestic politics and EU debates on responsibility-sharing.
+        </p>
+      </section>
 
     <section class="country-section-list">
       <article class="country-section-card">


### PR DESCRIPTION
## Summary
- add an Italian flag badge alongside the Italy page heading for visual context
- introduce shared country title and flag styling to support the accent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69282189a80883209a8ca59261a49452)