### PR TITLE
Add clickable homepage map navigation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -300,6 +300,9 @@ a {
   stroke: #111827;
   stroke-width: 0.4;
   transition: fill var(--transition-fast), stroke var(--transition-fast), stroke-width var(--transition-fast);
+}
+
+.interactive-map svg path.is-clickable {
   cursor: pointer;
 }
 
@@ -563,6 +566,72 @@ a {
   display: flex;
   flex-wrap: wrap;
   gap: 0.8rem;
+}
+
+.hero-visual {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 18px 48px rgba(6, 10, 20, 0.4);
+}
+
+.hero-visual .interactive-map {
+  background: radial-gradient(circle at 22% 18%, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02) 42%),
+    radial-gradient(circle at 80% 24%, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04) 48%),
+    rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.16);
+  min-height: 320px;
+}
+
+.map-cta {
+  margin-top: 1.1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.map-cta-eyebrow {
+  margin: 0 0 0.15rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.map-cta-text {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.map-cta-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.map-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.map-chip:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.32);
+  transform: translateY(-1px);
 }
 
 .hero-image-placeholder {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -175,6 +175,11 @@ document.addEventListener('DOMContentLoaded', () => {
           map.appendChild(tooltip);
 
           const paths = svg.querySelectorAll('path[id]');
+          const countryLinks = {
+            it: '/countries/italy.html',
+            es: '/countries/spain.html',
+            pt: '/countries/portugal.html'
+          };
 
           function hideTooltip() {
             tooltip.classList.remove('is-visible');
@@ -183,6 +188,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
           paths.forEach(path => {
             const countryName = path.getAttribute('name') || path.id;
+            const countryCode = (path.id || '').toLowerCase();
+            const target = countryLinks[countryCode];
 
             path.addEventListener('mouseenter', () => {
               tooltip.textContent = countryName;
@@ -197,6 +204,22 @@ document.addEventListener('DOMContentLoaded', () => {
               tooltip.style.left = `${event.clientX - rect.left + 12}px`;
               tooltip.style.top = `${event.clientY - rect.top + 12}px`;
             });
+
+            if (target) {
+              path.classList.add('is-clickable');
+              path.setAttribute('role', 'link');
+              path.setAttribute('tabindex', '0');
+              path.addEventListener('click', () => {
+                window.location.href = target;
+              });
+
+              path.addEventListener('keydown', event => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  path.click();
+                }
+              });
+            }
           });
 
           map.addEventListener('mouseleave', hideTooltip);

--- a/index.html
+++ b/index.html
@@ -47,8 +47,20 @@
       </div>
 
       <div class="hero-image">
-        <div class="hero-image-placeholder">
-          <span>Interactive map preview</span>
+        <div class="hero-visual">
+          <div class="interactive-map" data-map-src="assets/maps/europe.svg" aria-label="Interactive map of Europe"></div>
+          <div class="map-cta">
+            <div>
+              <p class="map-cta-eyebrow">Direct country access</p>
+              <p class="map-cta-text">Click a highlighted country to open its profile, or pick one below.</p>
+            </div>
+            <div class="map-cta-links">
+              <a class="map-chip" href="countries/italy.html">Italy</a>
+              <a class="map-chip" href="countries/portugal.html">Portugal</a>
+              <a class="map-chip" href="countries/spain.html">Spain</a>
+              <a class="map-chip" href="countries.html">All countries</a>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace the homepage hero placeholder with the interactive Europe map and direct country links
- add styling for the new hero map section and quick country chips
- make the SVG map paths clickable for available country profiles

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa6db155083228025c87783090a93)