### PR TITLE
Enlarge homepage map and fix interactive links

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -286,7 +286,7 @@ a {
   border-radius: 1rem;
   border: 1px solid #e0e4ef;
   overflow: hidden;
-  min-height: 260px;
+  min-height: 320px;
 }
 
 .interactive-map svg {
@@ -608,7 +608,7 @@ a {
   border-radius: 18px;
   padding: 1.75rem;
   box-shadow: 0 18px 48px rgba(6, 10, 20, 0.4);
-  min-height: 460px;
+  min-height: 560px;
   padding: 1.5rem;
   box-shadow: 0 18px 48px rgba(6, 10, 20, 0.4);
 }
@@ -618,8 +618,7 @@ a {
     radial-gradient(circle at 80% 24%, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04) 48%),
     rgba(255, 255, 255, 0.04);
   border-color: rgba(255, 255, 255, 0.16);
-  min-height: 440px;
-  min-height: 320px;
+  min-height: 520px;
 }
 
 .map-cta {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -176,11 +176,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
           const paths = svg.querySelectorAll('path[id]');
           const countryLinks = {
-            it: '/countries/italy.html',
-            es: '/countries/spain.html',
-            pt: '/countries/portugal.html',
-            lu: '/countries/luxembourg.html',
-            pl: '/countries/poland.html'
+            it: 'countries/italy.html',
+            es: 'countries/spain.html',
+            pt: 'countries/portugal.html',
+            lu: 'countries/luxembourg.html',
+            pl: 'countries/poland.html'
           };
 
           function hideTooltip() {

--- a/index.html
+++ b/index.html
@@ -46,21 +46,9 @@
         </div>
       </div>
 
-      <div class="hero-image">
+        <div class="hero-image">
         <div class="hero-visual">
           <div class="interactive-map" data-map-src="assets/maps/europe.svg" aria-label="Interactive map of Europe"></div>
-          <div class="map-cta">
-            <div>
-              <p class="map-cta-eyebrow">Direct country access</p>
-              <p class="map-cta-text">Click a highlighted country to open its profile, or pick one below.</p>
-            </div>
-            <div class="map-cta-links">
-              <a class="map-chip" href="countries/italy.html">Italy</a>
-              <a class="map-chip" href="countries/portugal.html">Portugal</a>
-              <a class="map-chip" href="countries/spain.html">Spain</a>
-              <a class="map-chip" href="countries.html">All countries</a>
-            </div>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enlarge the homepage hero map container for better visibility
- remove the direct country access chip links beneath the map
- use relative country profile paths for map interactions to avoid 404 errors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0f8badb08322bd2e0235d29d74ea)