### PR TITLE
Refine hero map container styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -606,22 +606,22 @@ a {
   gap: 0.8rem;
 }
 
+/* De hero-visual wraps de interactieve kaart op de homepage.
+   Subtielere stijl zonder zware rand of schaduw. */
 .hero-visual {
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 18px;
-  padding: 1.75rem;
-  box-shadow: 0 18px 48px rgba(6, 10, 20, 0.4);
-  min-height: 820px;
-  padding: 1.8rem;
-  box-shadow: 0 18px 48px rgba(6, 10, 20, 0.4);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015));
+  border: none;              /* geen rand meer */
+  border-radius: 14px;       /* iets kleinere afronding */
+  padding: 1.2rem;           /* minder witruimte rond de kaart */
+  box-shadow: 0 14px 36px rgba(6, 10, 20, 0.35);  /* subtielere schaduw */
+  min-height: 820px;         /* behoud hoogte zodat de kaart voldoende ruimte heeft */
 }
 
 .hero-visual .interactive-map {
   background: radial-gradient(circle at 22% 18%, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02) 42%),
     radial-gradient(circle at 80% 24%, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04) 48%),
     rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.12);
   min-height: 720px;
 }
 


### PR DESCRIPTION
## Summary
- restyle the hero visual wrapper with lighter gradient, no border, reduced padding, and softer shadow
- soften the interactive map border color for a less pronounced outline

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69404d03f7c8832086a3567b6285c869)