### PR TITLE
Restyle filter dropdown

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1308,7 +1308,7 @@ body.index .hero-visual .interactive-map {
   font-size: 0.95rem;
   font-weight: 600;
   line-height: 1.4;
-  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
   width: 100%;
   max-width: 320px;
   position: relative;
@@ -1324,11 +1324,19 @@ body.index .hero-visual .interactive-map {
 .filters-section select.filter-select {
   appearance: none;
   background-image:
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23003399' d='M1.41 0L6 4.58 10.59 0 12 1.41 6 7.41 0 1.41z'/%3E%3C/svg%3E");
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%231d4ed8' d='M1.41 0L6 4.58 10.59 0 12 1.41 6 7.41 0 1.41z'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 1.1rem center;
+  background-position: right 1.2rem center;
   background-size: 12px 8px;
-  padding-left: 1.25rem;
+  color: #1d4ed8;
+  padding: 0.6rem 2.4rem 0.6rem 1rem;
+  outline: none;
+}
+
+.filters-section select.filter-select:hover,
+.filters-section select.filter-select:focus-visible {
+  border-color: #2563eb;
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.15);
 }
 
 .filters-section input.filter-search-input::placeholder {


### PR DESCRIPTION
## Summary
- soften the country filter dropdown styling to mirror the search input with shared border, radius, and shadow
- add custom blue caret icon, typography tweaks, and hover/focus feedback for consistency with chips

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694075719d408320b7024af0a0f24c88)