### PR TITLE
Fix filter dropdown overflow and stacking

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1218,7 +1218,7 @@ body.index .hero-visual .interactive-map {
   flex-direction: column;
   gap: 0.75rem;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
   isolation: isolate;
 }
 
@@ -1376,7 +1376,7 @@ body.index .hero-visual .interactive-map {
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
   list-style: none;
   display: none;
-  z-index: 10;
+  z-index: 30;
 }
 
 .custom-select.open .select-options {


### PR DESCRIPTION
## Summary
- allow filter panel content to overflow so dropdown menus are not clipped
- raise the custom select options z-index so the dropdown appears above surrounding elements

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69407ee52da08320a56a354c12073016)