### PR TITLE
Fix dropdown stacking for filters

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1220,6 +1220,7 @@ body.index .hero-visual .interactive-map {
   position: relative;
   overflow: visible;
   isolation: isolate;
+  z-index: 2;
 }
 
 .filters-shell::after {
@@ -1334,6 +1335,7 @@ body.index .hero-visual .interactive-map {
   position: relative;
   width: 100%;
   max-width: 320px;
+  z-index: 3;
 }
 
 .custom-select .select-toggle {
@@ -1376,7 +1378,7 @@ body.index .hero-visual .interactive-map {
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
   list-style: none;
   display: none;
-  z-index: 30;
+  z-index: 50;
 }
 
 .custom-select.open .select-options {


### PR DESCRIPTION
## Summary
- set the filters container to establish a higher stacking context
- elevate custom select wrapper and dropdown options so they appear above chips and maps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694083b2e7888320aaa2600afe9ccda6)