### PR TITLE
Refine country filter dropdown styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1520,16 +1520,71 @@ body.index .hero-visual .interactive-map {
    Countries page: select styling and stack
    ---------------------------------------- */
 
-/* regioselectie heeft dezelfde vorm als het filterpaneel */
-.page-countries .custom-select,
-.page-countries .custom-select .select-toggle {
+/* Maak een volledig afgeronde omhulling voor de regioselectie */
+.country-filter-panel .region-select-wrapper {
+  position: relative;
+  z-index: 20;
+  display: inline-block;
   border-radius: 18px;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+  background: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  overflow: visible;
 }
 
-/* ook de dropdownlijst past zich aan de radius aan */
-.page-countries .custom-select .select-options {
+/* Het zichtbare deel van de dropdown: als een knop */
+.country-filter-panel .region-select-toggle {
+  padding: 0.7rem 1.5rem 0.7rem 1rem;
+  width: 100%;
+  border: none;
+  background: transparent;
+  font-weight: 600;
+  cursor: pointer;
+  position: relative;
+  text-align: left;
+}
+
+/* Pijltje rechts in de knop */
+.country-filter-panel .region-select-toggle::after {
+  content: '';
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  width: 0.5rem;
+  height: 0.5rem;
+  transform: translateY(-50%) rotate(45deg);
+  border-right: 2px solid #2563eb;
+  border-bottom: 2px solid #2563eb;
+  background-image: none;
+}
+
+/* De lijst met regio’s: afgerond en zwevend boven de chips/kaarten */
+.country-filter-panel .region-select-list {
+  display: none;
+  position: absolute;
+  left: 0;
+  top: 100%;
+  width: 100%;
+  margin-top: 0.25rem;
+  background: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.3);
   border-radius: 18px;
-  margin-top: 0.3rem;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+  list-style: none;
+  padding: 0.5rem 0;
+  z-index: 30;
+}
+
+/* Items in de open lijst */
+.country-filter-panel .region-select-list li {
+  padding: 0.6rem 1rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.country-filter-panel .region-select-list li:hover {
+  background: rgba(37, 99, 235, 0.1);
+  color: #2563eb;
 }
 
 /* filtershell en children vormen een hogere laag */
@@ -1539,19 +1594,8 @@ body.index .hero-visual .interactive-map {
   overflow: visible;
 }
 
-/* de select-wrapper krijgt een hogere z-index */
-.page-countries .custom-select {
-  position: relative;
-  z-index: 10;
-}
-
-/* de dropdownlijst wordt nog hoger geplaatst */
-.page-countries .custom-select .select-options {
-  z-index: 20;
-}
-
 /* verlaag de z-index van de topicchips zodat ze onder de dropdown blijven */
-.page-countries .topic-filter .filter-chips {
+.country-filter-panel .topic-filter .filter-chips {
   position: relative;
   z-index: 1;
 }

--- a/countries.html
+++ b/countries.html
@@ -43,7 +43,7 @@
 
       <!-- Filters: vervangt de kaart -->
       <div class="filters-section">
-        <div class="filters-shell">
+        <div class="filters-shell country-filter-panel">
           <div class="filters-heading">
             <span class="filters-eyebrow">Find a country</span>
             <h2 class="filters-title">Search by name or region</h2>
@@ -59,11 +59,11 @@
                 aria-label="Search countries"
               >
               <!-- Regio-filter -->
-              <div class="custom-select" data-selected="">
-                <button type="button" class="select-toggle" aria-haspopup="listbox" aria-expanded="false">
+              <div class="custom-select region-select-wrapper" data-selected="">
+                <button type="button" class="select-toggle region-select-toggle" aria-haspopup="listbox" aria-expanded="false">
                   <span class="select-label">All regions</span>
                 </button>
-                <ul class="select-options" role="listbox">
+                <ul class="select-options region-select-list" role="listbox">
                   <li data-value="" role="option" aria-selected="true" tabindex="0">All regions</li>
                   <li data-value="northern" role="option" tabindex="0">Northern Europe</li>
                   <li data-value="southern" role="option" tabindex="0">Southern Europe</li>


### PR DESCRIPTION
## Summary
- add region select wrapper styles to smooth rounding and elevate dropdown above chips
- tag country filter markup with new wrapper/toggle/list classes to use the custom styling

## Testing
- no automated tests were run (visual change)
- ✅ `python -m http.server 8000` (manual launch for visual verification)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69408c940f8c8320a32dbc0a62d366f3)