### PR TITLE
Adjust dropdown option spacing

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1371,7 +1371,7 @@ body.index .hero-visual .interactive-map {
   top: calc(100% + 0.2rem);
   width: 100%;
   margin: 0;
-  padding: 0.35rem 0;
+  padding: 0;
   background: #ffffff;
   border: 1px solid #e4e8ed;
   border-radius: 18px;
@@ -1379,6 +1379,7 @@ body.index .hero-visual .interactive-map {
   list-style: none;
   display: none;
   z-index: 50;
+  overflow: hidden;
 }
 
 .custom-select.open .select-options {


### PR DESCRIPTION
## Summary
- remove extra padding around the region dropdown option list
- ensure the dropdown menu corners remain smooth by clipping overflow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940961cd8908320ad0e491297caae41)