### PR TITLE
Align region dropdown highlights

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1636,17 +1636,27 @@ body.index .hero-visual .interactive-map {
   padding: 0.6rem 1rem;
   cursor: pointer;
   white-space: nowrap;
+  width: 100%;
+  box-sizing: border-box;
 }
 
-.country-filter-panel .region-select-list li:hover {
+.country-filter-panel .region-select-list li:hover,
+.country-filter-panel .region-select-list li[aria-selected="true"] {
   background: rgba(37, 99, 235, 0.1);
   color: #2563eb;
+  border-radius: 0;
 }
 
-.country-filter-panel .region-select-list li[aria-selected="true"] {
-  background: rgba(37, 99, 235, 0.12);
-  color: #1d4ed8;
-  border-radius: 12px;
+.country-filter-panel .region-select-list li:first-child:hover,
+.country-filter-panel .region-select-list li:first-child[aria-selected="true"] {
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+}
+
+.country-filter-panel .region-select-list li:last-child:hover,
+.country-filter-panel .region-select-list li:last-child[aria-selected="true"] {
+  border-bottom-left-radius: 14px;
+  border-bottom-right-radius: 14px;
 }
 
 /* filtershell en children vormen een hogere laag */


### PR DESCRIPTION
## Summary
- make region dropdown options span full width of the menu
- align hover and selected highlights to share the same styling
- maintain rounded corners on the first and last items to match the dropdown container

## Testing
- Not run (static change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940973c847c8320990cd2a1702fe197)