### PR TITLE
Fix map highlights for Luxembourg and Poland

### DIFF
--- a/countries/luxembourg.html
+++ b/countries/luxembourg.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>EU Migration Atlas – Spain</title>
+  <title>EU Migration Atlas – Luxembourg</title>
 
   <link rel="stylesheet" href="../assets/css/style.css" />
   <script defer src="../assets/js/main.js"></script>
@@ -46,7 +46,7 @@
    </div>
 
    <div class="overview-map">
-      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="es" aria-label="Interactive map of Europe highlighting Spain"></div>
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="lu" aria-label="Interactive map of Europe highlighting Luxembourg"></div>
    </div>
 </section>
       

--- a/countries/poland.html
+++ b/countries/poland.html
@@ -46,7 +46,7 @@
    </div>
 
    <div class="overview-map">
-      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="es" aria-label="Interactive map of Europe highlighting Spain"></div>
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="pl" aria-label="Interactive map of Europe highlighting Poland"></div>
    </div>
 </section>
       


### PR DESCRIPTION
## Summary
- correct Luxembourg page title and map highlight
- update Luxembourg and Poland overview maps to highlight the proper countries

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69410b2f93088320a9f9a2b176613fd5)