### PR TITLE
Add map highlights for Luxembourg and Poland

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -399,6 +399,20 @@ a {
   stroke-width: 1.2;
 }
 
+.country-lu #LU,
+.interactive-map.country-lu #LU {
+  fill: #2563eb;
+  stroke: #1e293b;
+  stroke-width: 1.2;
+}
+
+.country-pl #PL,
+.interactive-map.country-pl #PL {
+  fill: #2563eb;
+  stroke: #1e293b;
+  stroke-width: 1.2;
+}
+
 .country-section-list {
   margin-top: 2.5rem;
   display: flex;


### PR DESCRIPTION
## Summary
- highlight Luxembourg and Poland on the interactive map so their country pages show the correct focus

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69410c0619c083208a52eaf6609e83ed)