### PR TITLE
Link interactive map to country pages

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -177,13 +177,21 @@ document.addEventListener('DOMContentLoaded', () => {
           map.appendChild(tooltip);
 
           const paths = svg.querySelectorAll('path[id]');
-          const countryLinks = {
+          const countryProfiles = {
             it: 'countries/italy.html',
             es: 'countries/spain.html',
             pt: 'countries/portugal.html',
             lu: 'countries/luxembourg.html',
             pl: 'countries/poland.html'
           };
+
+          // EU Member States get at least a fallback link to the Countries overview
+          // so the homepage map always opens a relevant page when clicked.
+          const euCountryCodes = new Set([
+            'at', 'be', 'bg', 'hr', 'cy', 'cz', 'dk', 'ee', 'fi', 'fr', 'de',
+            'gr', 'hu', 'ie', 'it', 'lv', 'lt', 'lu', 'mt', 'nl', 'pl', 'pt',
+            'ro', 'sk', 'si', 'es', 'se'
+          ]);
 
           // Resolve the correct base path so map clicks work on GitHub Pages and local dev
           const baseHref = (() => {
@@ -203,7 +211,7 @@ document.addEventListener('DOMContentLoaded', () => {
           paths.forEach(path => {
             const countryName = path.getAttribute('name') || path.id;
             const countryCode = (path.id || '').toLowerCase();
-            const target = countryLinks[countryCode];
+            const target = countryProfiles[countryCode] || (euCountryCodes.has(countryCode) ? `countries.html#${countryCode}` : null);
 
             path.addEventListener('mouseenter', () => {
               tooltip.textContent = countryName;

--- a/countries.html
+++ b/countries.html
@@ -89,7 +89,7 @@
       <div class="country-grid">
 
         <!-- Luxembourg -->
-        <a href="countries/luxembourg.html" class="country-card" data-region="western" data-topic="high-recognition humanitarian-focus">
+        <a href="countries/luxembourg.html" id="lu" class="country-card" data-region="western" data-topic="high-recognition humanitarian-focus">
           <div class="country-code">LU</div>
           <h2>Luxembourg</h2>
           <p>
@@ -99,7 +99,7 @@
         </a>
 
         <!-- Italy -->
-        <a href="countries/italy.html" class="country-card" data-region="southern" data-topic="strict-policy humanitarian-focus labour-migration">
+        <a href="countries/italy.html" id="it" class="country-card" data-region="southern" data-topic="strict-policy humanitarian-focus labour-migration">
           <div class="country-code">IT</div>
           <h2>Italy</h2>
           <p>
@@ -110,7 +110,7 @@
         </a>
 
         <!-- Poland -->
-        <a href="countries/poland.html" class="country-card" data-region="eastern" data-topic="strict-policy">
+        <a href="countries/poland.html" id="pl" class="country-card" data-region="eastern" data-topic="strict-policy">
           <div class="country-code">PL</div>
           <h2>Poland</h2>
           <p>
@@ -120,7 +120,7 @@
         </a>
 
         <!-- Portugal -->
-        <a href="countries/portugal.html" class="country-card" data-region="southern" data-topic="high-recognition labour-migration humanitarian-focus">
+        <a href="countries/portugal.html" id="pt" class="country-card" data-region="southern" data-topic="high-recognition labour-migration humanitarian-focus">
           <div class="country-code">PT</div>
           <h2>Portugal</h2>
           <p>
@@ -130,7 +130,7 @@
         </a>
 
         <!-- Spain -->
-        <a href="countries/spain.html" class="country-card" data-region="southern" data-topic="high-recognition humanitarian-focus labour-migration">
+        <a href="countries/spain.html" id="es" class="country-card" data-region="southern" data-topic="high-recognition humanitarian-focus labour-migration">
           <div class="country-code">ES</div>
           <h2>Spain</h2>
           <p>


### PR DESCRIPTION
## Summary
- add EU fallback destinations for map regions so clicking countries opens the relevant profile or country overview
- attach anchor ids to existing country cards to support hash links from the interactive map

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694117e1dde48320b7962c55bb6a84e3)