### PR TITLE
Limit map highlights to EU members

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -300,10 +300,18 @@ a {
 }
 
 .interactive-map svg path {
-  fill: #e7eaf3;
+  fill: #f1f3f8;
   stroke: #111827;
   stroke-width: 0.4;
   transition: fill var(--transition-fast), stroke var(--transition-fast), stroke-width var(--transition-fast);
+}
+
+.interactive-map svg path.eu-member {
+  fill: #d9dde7;
+}
+
+.interactive-map svg path.non-eu {
+  fill: #f7f8fc;
 }
 
 .interactive-map svg path.is-clickable {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -211,12 +211,17 @@ document.addEventListener('DOMContentLoaded', () => {
           paths.forEach(path => {
             const countryName = path.getAttribute('name') || path.id;
             const countryCode = (path.id || '').toLowerCase();
-            const target = countryProfiles[countryCode] || (euCountryCodes.has(countryCode) ? `countries.html#${countryCode}` : null);
+            const isEuMember = euCountryCodes.has(countryCode);
+            const target = countryProfiles[countryCode] || (isEuMember ? `countries.html#${countryCode}` : null);
+
+            path.classList.add(isEuMember ? 'eu-member' : 'non-eu');
 
             path.addEventListener('mouseenter', () => {
               tooltip.textContent = countryName;
               tooltip.classList.add('is-visible');
-              path.classList.add('is-hovered');
+              if (isEuMember) {
+                path.classList.add('is-hovered');
+              }
             });
 
             path.addEventListener('mouseleave', hideTooltip);


### PR DESCRIPTION
## Summary
- mark EU member states on all Europe maps and apply muted default highlights
- keep non-EU countries de-emphasized while preserving hover/click behavior for EU states only

## Testing
- not run (static changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69411bf3352483208e53570b1a51668e)