### PR TITLE
Link all country profiles and alphabetize listing

### DIFF
--- a/countries.html
+++ b/countries.html
@@ -88,13 +88,115 @@
 
       <div class="country-grid">
 
-        <!-- Luxembourg -->
-        <a href="countries/luxembourg.html" id="lu" class="country-card" data-region="western" data-topic="high-recognition humanitarian-focus">
-          <div class="country-code">LU</div>
-          <h2>Luxembourg</h2>
-          <p>
-            Add additional text here.
-          </p>
+        <!-- Austria -->
+        <a href="countries/austria.html" id="at" class="country-card" data-region="western" data-topic="strict-policy labour-migration">
+          <div class="country-code">AT</div>
+          <h2>Austria</h2>
+          <p>Schengen member balancing humanitarian duties with firm border controls.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Belgium -->
+        <a href="countries/belgium.html" id="be" class="country-card" data-region="western" data-topic="high-recognition labour-migration">
+          <div class="country-code">BE</div>
+          <h2>Belgium</h2>
+          <p>Federal system coordinating asylum reception across regions and communities.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Bulgaria -->
+        <a href="countries/bulgaria.html" id="bg" class="country-card" data-region="eastern" data-topic="strict-policy">
+          <div class="country-code">BG</div>
+          <h2>Bulgaria</h2>
+          <p>Border state on the EU’s external frontier with a focus on security and returns.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Croatia -->
+        <a href="countries/croatia.html" id="hr" class="country-card" data-region="southern" data-topic="labour-migration humanitarian-focus">
+          <div class="country-code">HR</div>
+          <h2>Croatia</h2>
+          <p>Newer Schengen member strengthening reception while managing Balkan route flows.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Cyprus -->
+        <a href="countries/cyprus.html" id="cy" class="country-card" data-region="southern" data-topic="high-recognition humanitarian-focus">
+          <div class="country-code">CY</div>
+          <h2>Cyprus</h2>
+          <p>Island state facing high asylum pressure relative to population size.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Czechia -->
+        <a href="countries/czechia.html" id="cz" class="country-card" data-region="eastern" data-topic="strict-policy">
+          <div class="country-code">CZ</div>
+          <h2>Czechia</h2>
+          <p>Central European state prioritising security vetting and temporary protection.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Denmark -->
+        <a href="countries/denmark.html" id="dk" class="country-card" data-region="northern" data-topic="strict-policy labour-migration">
+          <div class="country-code">DK</div>
+          <h2>Denmark</h2>
+          <p>Opt-out EU member with restrictive asylum rules and labour migration schemes.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Estonia -->
+        <a href="countries/estonia.html" id="ee" class="country-card" data-region="northern" data-topic="high-recognition labour-migration">
+          <div class="country-code">EE</div>
+          <h2>Estonia</h2>
+          <p>Digital-first administration managing migration with streamlined e-services.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Finland -->
+        <a href="countries/finland.html" id="fi" class="country-card" data-region="northern" data-topic="humanitarian-focus labour-migration">
+          <div class="country-code">FI</div>
+          <h2>Finland</h2>
+          <p>Nordic system emphasising protection standards and orderly labour pathways.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- France -->
+        <a href="countries/france.html" id="fr" class="country-card" data-region="western" data-topic="humanitarian-focus high-recognition">
+          <div class="country-code">FR</div>
+          <h2>France</h2>
+          <p>Major destination balancing humanitarian reception with integration priorities.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Germany -->
+        <a href="countries/germany.html" id="de" class="country-card" data-region="western" data-topic="labour-migration high-recognition">
+          <div class="country-code">DE</div>
+          <h2>Germany</h2>
+          <p>Largest EU recipient of protection seekers with reformed skilled migration laws.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Greece -->
+        <a href="countries/greece.html" id="gr" class="country-card" data-region="southern" data-topic="strict-policy">
+          <div class="country-code">GR</div>
+          <h2>Greece</h2>
+          <p>Frontline state managing Aegean arrivals through EU-Türkiye cooperation.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Hungary -->
+        <a href="countries/hungary.html" id="hu" class="country-card" data-region="eastern" data-topic="strict-policy labour-migration">
+          <div class="country-code">HU</div>
+          <h2>Hungary</h2>
+          <p>Implements fence-based border controls and limited asylum access points.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Ireland -->
+        <a href="countries/ireland.html" id="ie" class="country-card" data-region="western" data-topic="humanitarian-focus">
+          <div class="country-code">IE</div>
+          <h2>Ireland</h2>
+          <p>Common Travel Area member overhauling reception and direct provision systems.</p>
           <span class="country-more">View profile →</span>
         </a>
 
@@ -109,13 +211,51 @@
           <span class="country-more">View profile →</span>
         </a>
 
+        <!-- Latvia -->
+        <a href="countries/latvia.html" id="lv" class="country-card" data-region="northern" data-topic="strict-policy">
+          <div class="country-code">LV</div>
+          <h2>Latvia</h2>
+          <p>Border state emphasising security screenings and rapid response capacity.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Lithuania -->
+        <a href="countries/lithuania.html" id="lt" class="country-card" data-region="eastern" data-topic="strict-policy labour-migration">
+          <div class="country-code">LT</div>
+          <h2>Lithuania</h2>
+          <p>Developing asylum infrastructure after recent hybrid border pressures.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Luxembourg -->
+        <a href="countries/luxembourg.html" id="lu" class="country-card" data-region="western" data-topic="high-recognition humanitarian-focus">
+          <div class="country-code">LU</div>
+          <h2>Luxembourg</h2>
+          <p>Small state with coordinated reception services and multilingual integration.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Malta -->
+        <a href="countries/malta.html" id="mt" class="country-card" data-region="southern" data-topic="high-recognition humanitarian-focus">
+          <div class="country-code">MT</div>
+          <h2>Malta</h2>
+          <p>Mediterranean island managing boat arrivals with EU burden-sharing calls.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Netherlands -->
+        <a href="countries/netherlands.html" id="nl" class="country-card" data-region="western" data-topic="labour-migration high-recognition">
+          <div class="country-code">NL</div>
+          <h2>Netherlands</h2>
+          <p>Focuses on skilled migration, civic integration, and decentralised reception.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
         <!-- Poland -->
         <a href="countries/poland.html" id="pl" class="country-card" data-region="eastern" data-topic="strict-policy">
           <div class="country-code">PL</div>
           <h2>Poland</h2>
-          <p>
-            Add additional text here.
-          </p>
+          <p>Hosts millions under temporary protection while reinforcing eastern borders.</p>
           <span class="country-more">View profile →</span>
         </a>
 
@@ -123,9 +263,31 @@
         <a href="countries/portugal.html" id="pt" class="country-card" data-region="southern" data-topic="high-recognition labour-migration humanitarian-focus">
           <div class="country-code">PT</div>
           <h2>Portugal</h2>
-          <p>
-            Add additional text here.
-          </p>
+          <p>Proactive recruitment of workers paired with inclusive integration policies.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Romania -->
+        <a href="countries/romania.html" id="ro" class="country-card" data-region="eastern" data-topic="humanitarian-focus labour-migration">
+          <div class="country-code">RO</div>
+          <h2>Romania</h2>
+          <p>Key hub for Ukrainian displacement response and managed labour inflows.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Slovakia -->
+        <a href="countries/slovakia.html" id="sk" class="country-card" data-region="eastern" data-topic="strict-policy">
+          <div class="country-code">SK</div>
+          <h2>Slovakia</h2>
+          <p>Border management emphasises security cooperation and temporary protection.</p>
+          <span class="country-more">View profile →</span>
+        </a>
+
+        <!-- Slovenia -->
+        <a href="countries/slovenia.html" id="si" class="country-card" data-region="southern" data-topic="humanitarian-focus">
+          <div class="country-code">SI</div>
+          <h2>Slovenia</h2>
+          <p>Bridges Balkan and Alpine routes with solidarity-based relocation pledges.</p>
           <span class="country-more">View profile →</span>
         </a>
 
@@ -139,160 +301,13 @@
           <span class="country-more">View profile →</span>
         </a>
 
-        <!-- Placeholders for other countries -->
-        <div class="country-card country-card--placeholder" data-region="western" data-topic="strict-policy labour-migration">
-          <div class="country-code">AT</div>
-          <h2>Austria</h2>
-          <p>Placeholder for the Austrian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="western" data-topic="high-recognition labour-migration">
-          <div class="country-code">BE</div>
-          <h2>Belgium</h2>
-          <p>Placeholder for the Belgian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="eastern" data-topic="strict-policy">
-          <div class="country-code">BG</div>
-          <h2>Bulgaria</h2>
-          <p>Placeholder for the Bulgarian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="southern" data-topic="labour-migration humanitarian-focus">
-          <div class="country-code">HR</div>
-          <h2>Croatia</h2>
-          <p>Placeholder for the Croatian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-        <div class="country-card country-card--placeholder" data-region="southern" data-topic="high-recognition humanitarian-focus">
-          <div class="country-code">CY</div>
-          <h2>Cyprus</h2>
-          <p>Placeholder for the Cypriot profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="eastern" data-topic="strict-policy">
-          <div class="country-code">CY</div>
-          <h2>Czechia</h2>
-          <p>Placeholder for the Czech profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="northern" data-topic="strict-policy labour-migration">
-          <div class="country-code">DK</div>
-          <h2>Denmark</h2>
-          <p>Placeholder for the Danish profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="northern" data-topic="high-recognition labour-migration">
-          <div class="country-code">EE</div>
-          <h2>Estonia</h2>
-          <p>Placeholder for the Estonian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="northern" data-topic="humanitarian-focus labour-migration">
-          <div class="country-code">FI</div>
-          <h2>Finland</h2>
-          <p>Placeholder for the Finnish profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="western" data-topic="humanitarian-focus high-recognition">
-          <div class="country-code">FR</div>
-          <h2>France</h2>
-          <p>Placeholder for the French profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-        <div class="country-card country-card--placeholder" data-region="western" data-topic="labour-migration high-recognition">
-          <div class="country-code">DE</div>
-          <h2>Germany</h2>
-          <p>Placeholder for the German profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="southern" data-topic="strict-policy">
-          <div class="country-code">GR</div>
-          <h2>Greece</h2>
-          <p>Placeholder for the Greece profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="eastern" data-topic="strict-policy labour-migration">
-          <div class="country-code">HU</div>
-          <h2>Hungary</h2>
-          <p>Placeholder for the Hungarian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="western" data-topic="humanitarian-focus">
-          <div class="country-code">IE</div>
-          <h2>Ireland</h2>
-          <p>Placeholder for the Irish profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="northern" data-topic="strict-policy">
-          <div class="country-code">LV</div>
-          <h2>Latvia</h2>
-          <p>Placeholder for the Latvian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="eastern" data-topic="strict-policy labour-migration">
-          <div class="country-code">LT</div>
-          <h2>Lithuania</h2>
-          <p>Placeholder for the Lithuanian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="southern" data-topic="high-recognition humanitarian-focus">
-          <div class="country-code">MT</div>
-          <h2>Malta</h2>
-          <p>Placeholder for the Malta profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="western" data-topic="labour-migration high-recognition">
-          <div class="country-code">NL</div>
-          <h2>Netherlands</h2>
-          <p>Placeholder for the Dutch profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="eastern" data-topic="humanitarian-focus labour-migration">
-          <div class="country-code">RO</div>
-          <h2>Romania</h2>
-          <p>Placeholder for the Romanian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="eastern" data-topic="strict-policy">
-          <div class="country-code">SK</div>
-          <h2>Slovakia</h2>
-          <p>Placeholder for the Slovakian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="southern" data-topic="humanitarian-focus">
-          <div class="country-code">SI</div>
-          <h2>Slovenia</h2>
-          <p>Placeholder for the Slovenian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
-
-         <div class="country-card country-card--placeholder" data-region="northern" data-topic="high-recognition humanitarian-focus">
+        <!-- Sweden -->
+        <a href="countries/sweden.html" id="se" class="country-card" data-region="northern" data-topic="high-recognition humanitarian-focus">
           <div class="country-code">SE</div>
           <h2>Sweden</h2>
-          <p>Placeholder for the Slovenian profile. To be completed by the team.</p>
-          <span class="country-more">Coming soon</span>
-        </div>
+          <p>Long-standing refugee destination now tightening rules while supporting integration.</p>
+          <span class="country-more">View profile →</span>
+        </a>
 
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add linked cards for every member-state profile on countries page and remove placeholders
- reorder the country grid alphabetically with updated descriptions for each profile

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69412dcb72948320ace3e33259b9020c)