### PR TITLE
Create templates for remaining country pages

### DIFF
--- a/countries/austria.html
+++ b/countries/austria.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Austria</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-at">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-austria" role="img" aria-label="Flag of Austria"></span>
+          <h1>Austria</h1>
+        </div>
+        <p>
+          Add an introductory overview for Austria here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Austria within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="at" aria-label="Interactive map of Europe highlighting Austria"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Austria.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Austria.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Austria.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Austria.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/belgium.html
+++ b/countries/belgium.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Belgium</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-be">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-belgium" role="img" aria-label="Flag of Belgium"></span>
+          <h1>Belgium</h1>
+        </div>
+        <p>
+          Add an introductory overview for Belgium here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Belgium within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="be" aria-label="Interactive map of Europe highlighting Belgium"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Belgium.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Belgium.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Belgium.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Belgium.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/bulgaria.html
+++ b/countries/bulgaria.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Bulgaria</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-bg">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-bulgaria" role="img" aria-label="Flag of Bulgaria"></span>
+          <h1>Bulgaria</h1>
+        </div>
+        <p>
+          Add an introductory overview for Bulgaria here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Bulgaria within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="bg" aria-label="Interactive map of Europe highlighting Bulgaria"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Bulgaria.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Bulgaria.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Bulgaria.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Bulgaria.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/croatia.html
+++ b/countries/croatia.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Croatia</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-hr">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-croatia" role="img" aria-label="Flag of Croatia"></span>
+          <h1>Croatia</h1>
+        </div>
+        <p>
+          Add an introductory overview for Croatia here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Croatia within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="hr" aria-label="Interactive map of Europe highlighting Croatia"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Croatia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Croatia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Croatia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Croatia.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/cyprus.html
+++ b/countries/cyprus.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Cyprus</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-cy">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-cyprus" role="img" aria-label="Flag of Cyprus"></span>
+          <h1>Cyprus</h1>
+        </div>
+        <p>
+          Add an introductory overview for Cyprus here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Cyprus within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="cy" aria-label="Interactive map of Europe highlighting Cyprus"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Cyprus.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Cyprus.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Cyprus.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Cyprus.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/czechia.html
+++ b/countries/czechia.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Czechia</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-cz">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-czechia" role="img" aria-label="Flag of Czechia"></span>
+          <h1>Czechia</h1>
+        </div>
+        <p>
+          Add an introductory overview for Czechia here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Czechia within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="cz" aria-label="Interactive map of Europe highlighting Czechia"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Czechia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Czechia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Czechia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Czechia.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/denmark.html
+++ b/countries/denmark.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Denmark</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-dk">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-denmark" role="img" aria-label="Flag of Denmark"></span>
+          <h1>Denmark</h1>
+        </div>
+        <p>
+          Add an introductory overview for Denmark here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Denmark within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="dk" aria-label="Interactive map of Europe highlighting Denmark"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Denmark.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Denmark.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Denmark.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Denmark.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/estonia.html
+++ b/countries/estonia.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Estonia</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-ee">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-estonia" role="img" aria-label="Flag of Estonia"></span>
+          <h1>Estonia</h1>
+        </div>
+        <p>
+          Add an introductory overview for Estonia here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Estonia within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="ee" aria-label="Interactive map of Europe highlighting Estonia"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Estonia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Estonia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Estonia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Estonia.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/finland.html
+++ b/countries/finland.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Finland</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-fi">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-finland" role="img" aria-label="Flag of Finland"></span>
+          <h1>Finland</h1>
+        </div>
+        <p>
+          Add an introductory overview for Finland here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Finland within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="fi" aria-label="Interactive map of Europe highlighting Finland"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Finland.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Finland.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Finland.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Finland.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/france.html
+++ b/countries/france.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – France</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-fr">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-france" role="img" aria-label="Flag of France"></span>
+          <h1>France</h1>
+        </div>
+        <p>
+          Add an introductory overview for France here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of France within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="fr" aria-label="Interactive map of Europe highlighting France"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in France.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for France.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in France.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in France.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/germany.html
+++ b/countries/germany.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Germany</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-de">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-germany" role="img" aria-label="Flag of Germany"></span>
+          <h1>Germany</h1>
+        </div>
+        <p>
+          Add an introductory overview for Germany here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Germany within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="de" aria-label="Interactive map of Europe highlighting Germany"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Germany.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Germany.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Germany.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Germany.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/greece.html
+++ b/countries/greece.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Greece</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-gr">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-greece" role="img" aria-label="Flag of Greece"></span>
+          <h1>Greece</h1>
+        </div>
+        <p>
+          Add an introductory overview for Greece here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Greece within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="gr" aria-label="Interactive map of Europe highlighting Greece"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Greece.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Greece.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Greece.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Greece.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/hungary.html
+++ b/countries/hungary.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Hungary</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-hu">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-hungary" role="img" aria-label="Flag of Hungary"></span>
+          <h1>Hungary</h1>
+        </div>
+        <p>
+          Add an introductory overview for Hungary here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Hungary within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="hu" aria-label="Interactive map of Europe highlighting Hungary"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Hungary.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Hungary.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Hungary.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Hungary.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/ireland.html
+++ b/countries/ireland.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Ireland</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-ie">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-ireland" role="img" aria-label="Flag of Ireland"></span>
+          <h1>Ireland</h1>
+        </div>
+        <p>
+          Add an introductory overview for Ireland here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Ireland within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="ie" aria-label="Interactive map of Europe highlighting Ireland"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Ireland.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Ireland.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Ireland.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Ireland.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/latvia.html
+++ b/countries/latvia.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Latvia</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-lv">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-latvia" role="img" aria-label="Flag of Latvia"></span>
+          <h1>Latvia</h1>
+        </div>
+        <p>
+          Add an introductory overview for Latvia here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Latvia within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="lv" aria-label="Interactive map of Europe highlighting Latvia"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Latvia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Latvia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Latvia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Latvia.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/lithuania.html
+++ b/countries/lithuania.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Lithuania</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-lt">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-lithuania" role="img" aria-label="Flag of Lithuania"></span>
+          <h1>Lithuania</h1>
+        </div>
+        <p>
+          Add an introductory overview for Lithuania here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Lithuania within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="lt" aria-label="Interactive map of Europe highlighting Lithuania"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Lithuania.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Lithuania.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Lithuania.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Lithuania.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/malta.html
+++ b/countries/malta.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Malta</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-mt">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-malta" role="img" aria-label="Flag of Malta"></span>
+          <h1>Malta</h1>
+        </div>
+        <p>
+          Add an introductory overview for Malta here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Malta within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="mt" aria-label="Interactive map of Europe highlighting Malta"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Malta.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Malta.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Malta.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Malta.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/netherlands.html
+++ b/countries/netherlands.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Netherlands</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-nl">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-netherlands" role="img" aria-label="Flag of Netherlands"></span>
+          <h1>Netherlands</h1>
+        </div>
+        <p>
+          Add an introductory overview for Netherlands here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Netherlands within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="nl" aria-label="Interactive map of Europe highlighting Netherlands"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Netherlands.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Netherlands.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Netherlands.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Netherlands.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/romania.html
+++ b/countries/romania.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Romania</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-ro">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-romania" role="img" aria-label="Flag of Romania"></span>
+          <h1>Romania</h1>
+        </div>
+        <p>
+          Add an introductory overview for Romania here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Romania within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="ro" aria-label="Interactive map of Europe highlighting Romania"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Romania.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Romania.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Romania.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Romania.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/slovakia.html
+++ b/countries/slovakia.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Slovakia</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-sk">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-slovakia" role="img" aria-label="Flag of Slovakia"></span>
+          <h1>Slovakia</h1>
+        </div>
+        <p>
+          Add an introductory overview for Slovakia here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Slovakia within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="sk" aria-label="Interactive map of Europe highlighting Slovakia"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Slovakia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Slovakia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Slovakia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Slovakia.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/slovenia.html
+++ b/countries/slovenia.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Slovenia</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-si">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-slovenia" role="img" aria-label="Flag of Slovenia"></span>
+          <h1>Slovenia</h1>
+        </div>
+        <p>
+          Add an introductory overview for Slovenia here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Slovenia within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="si" aria-label="Interactive map of Europe highlighting Slovenia"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Slovenia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Slovenia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Slovenia.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Slovenia.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/countries/sweden.html
+++ b/countries/sweden.html
@@ -1,1 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EU Migration Atlas – Sweden</title>
 
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <script defer src="../assets/js/main.js"></script>
+</head>
+
+<body class="page-country country-se">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="../index.html" class="logo">
+        <img src="../assets/logo-atlas.png" alt="European Migration Policy Atlas logo" class="logo-image" />
+      </a>
+
+      <nav class="main-nav">
+        <a href="../index.html" data-page="home">Home</a>
+        <a href="../countries.html" data-page="countries">Countries</a>
+        <a href="../compare.html" data-page="compare">Compare</a>
+        <a href="../assistant.html" data-page="assistant">Atlas AI</a>
+        <a href="../about.html" data-page="about">About</a>
+      </nav>
+    </div>
+  </header>
+
+    <main class="page-main">
+      <section class="page-intro">
+        <div class="country-title">
+          <span class="country-flag flag-sweden" role="img" aria-label="Flag of Sweden"></span>
+          <h1>Sweden</h1>
+        </div>
+        <p>
+          Add an introductory overview for Sweden here.
+        </p>
+      </section>
+
+<section class="country-overview">
+   <div class="overview-text">
+      <h2>Europe at a glance</h2>
+      <p>Provide a short summary of Sweden within the European context.</p>
+   </div>
+
+   <div class="overview-map">
+      <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="se" aria-label="Interactive map of Europe highlighting Sweden"></div>
+   </div>
+</section>
+
+    <section class="country-section-list">
+      <article class="country-section-card">
+        <div class="country-section-tag">PC</div>
+        <h2>Political climate</h2>
+        <p>
+          Add notes about the political climate in Sweden.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">MS</div>
+        <h2>Migration statistics</h2>
+        <p>
+          Summarize key migration statistics for Sweden.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">CP</div>
+        <h2>Current policies</h2>
+        <p>
+          Outline current migration policies in Sweden.
+        </p>
+      </article>
+
+      <article class="country-section-card">
+        <div class="country-section-tag">AP</div>
+        <h2>Application possibilities</h2>
+        <p>
+          Describe application and integration possibilities in Sweden.
+        </p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <p class="footer-left">
+        © 2025 EU Migration Atlas – Cross-Border Migration, Governance &amp; Security
+      </p>
+      <p class="footer-right">
+        Fictional project for DG Migration &amp; Home Affairs (DG HOME)
+      </p>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Spain-style layout to previously empty country pages
- include country-specific flag, map highlight, and section placeholders for each page

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694130a450b88320a38c9a156118228c)