### PR TITLE
Enhance country map highlighting and styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -307,11 +307,11 @@ a {
 }
 
 .interactive-map svg path.eu-member {
-  fill: #d9dde7;
+  fill: #c3c9da;
 }
 
 .interactive-map svg path.non-eu {
-  fill: #f7f8fc;
+  fill: rgba(241, 243, 248, 0.45);
 }
 
 .interactive-map svg path.is-clickable {
@@ -385,37 +385,8 @@ a {
   }
 }
 
-/* active countries per page */
-.country-it #IT,
-.interactive-map.country-it #IT {
-  fill: #2563eb;
-  stroke: #1e293b;
-  stroke-width: 1.2;
-}
-
-.country-es #ES,
-.interactive-map.country-es #ES {
-  fill: #2563eb;
-  stroke: #1e293b;
-  stroke-width: 1.2;
-}
-
-.country-pt #PT,
-.interactive-map.country-pt #PT {
-  fill: #2563eb;
-  stroke: #1e293b;
-  stroke-width: 1.2;
-}
-
-.country-lu #LU,
-.interactive-map.country-lu #LU {
-  fill: #2563eb;
-  stroke: #1e293b;
-  stroke-width: 1.2;
-}
-
-.country-pl #PL,
-.interactive-map.country-pl #PL {
+/* active country highlight for any page */
+.interactive-map svg path.is-highlighted {
   fill: #2563eb;
   stroke: #1e293b;
   stroke-width: 1.2;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -185,6 +185,15 @@ document.addEventListener('DOMContentLoaded', () => {
             pl: 'countries/poland.html'
           };
 
+          const activeCode = highlight || '';
+          if (activeCode) {
+            const targetPath = svg.querySelector(`#${activeCode.toUpperCase()}`);
+            if (targetPath) {
+              targetPath.classList.add('is-highlighted');
+              targetPath.setAttribute('aria-current', 'true');
+            }
+          }
+
           // EU Member States get at least a fallback link to the Countries overview
           // so the homepage map always opens a relevant page when clicked.
           const euCountryCodes = new Set([


### PR DESCRIPTION
## Summary
- add a generic highlighted state for map countries so each profile page marks its country
- automatically apply the highlight based on the map data attribute when the SVG loads
- darken EU member states and lighten non-member states on Europe maps

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694132730788832080c870f66ca786df)