### PR TITLE
Make non-EU countries outlined on all maps

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -311,7 +311,8 @@ a {
 }
 
 .interactive-map svg path.non-eu {
-  fill: rgba(241, 243, 248, 0.45);
+  fill: transparent;
+  stroke: rgba(15, 23, 42, 0.35);
 }
 
 .interactive-map svg path.is-clickable {


### PR DESCRIPTION
## Summary
- render non-EU countries as transparent with a subtle outline so EU members remain emphasized across all maps

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941350906b083209427cd501a532d02)