### PR TITLE
Make non-EU countries transparent on homepage map

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -300,7 +300,7 @@ a {
 }
 
 .interactive-map svg path {
-  fill: #f1f3f8;
+  fill: none;
   stroke: #111827;
   stroke-width: 0.4;
   transition: fill var(--transition-fast), stroke var(--transition-fast), stroke-width var(--transition-fast);


### PR DESCRIPTION
## Summary
- remove the default fill from the interactive map so only EU members have a fill color
- keep non-EU countries fully transparent while retaining visible borders

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694136ac5bd88320a4c857462155a8ca)