### PR TITLE
Adjust homepage map contrast for non-EU borders

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1170,6 +1170,11 @@ body.index .hero-visual .interactive-map {
   min-height: 600px;                /* pas de hoogte eventueel aan */
 }
 
+/* Maak de grenzen van niet-EU-landen wit op de homepage zodat ze zichtbaar blijven */
+body.index .interactive-map svg path.non-eu {
+  stroke: rgba(255, 255, 255, 0.8);
+}
+
 /* Countries page filter section */
 
 .page-countries .filters-section {


### PR DESCRIPTION
## Summary
- update homepage map styling so non-EU country borders render in white for better contrast on the dark hero background

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694137ee7b0883209ff4cc287d20b5c3)