### PR TITLE
Update theme toggle and dark mode styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -60,11 +60,11 @@
 }
 
 body.theme-dark {
-  --bg-page: #0b1220;
-  --bg-surface-dark: #0c1323;
-  --bg-surface-elevated: #0f192b;
-  --bg-light: #0f172a;
-  --bg-light-soft: #111827;
+  --bg-page: #121416;
+  --bg-surface-dark: #161a20;
+  --bg-surface-elevated: #1c2029;
+  --bg-light: #1a1f27;
+  --bg-light-soft: #1f2530;
 
   --text-main: #e5e7eb;
   --text-muted: #cbd5e1;
@@ -117,7 +117,7 @@ body {
 }
 
 body.compare-page {
-  background: #0f172a;
+  background: #131821;
   color: var(--cmp-card-text);
 }
 
@@ -603,6 +603,11 @@ a {
   justify-content: center;
 }
 
+.theme-toggle__icon svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
 .theme-toggle__label {
   font-size: 0.9rem;
 }
@@ -639,7 +644,7 @@ body.theme-light .theme-toggle {
    ======================================== */
 
 .hero {
-  background: linear-gradient(135deg, #0f1b34 0%, #0b1224 45%, #0d1430 100%);
+  background: linear-gradient(135deg, #161a20 0%, #0f1218 45%, #1f262f 100%);
   color: var(--text-invert);
   padding: 4rem 0 3.5rem;
 }
@@ -1340,6 +1345,25 @@ body.index .interactive-map svg path.non-eu {
   z-index: 1;
 }
 
+body.theme-dark .filters-shell {
+  background: linear-gradient(145deg, #1f252f 0%, #141821 42%, #0d0f15 100%);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.45);
+}
+
+body.theme-dark .filters-shell::after {
+  background: radial-gradient(circle at 15% 22%, rgba(59, 130, 246, 0.12), transparent 42%),
+              radial-gradient(circle at 88% 24%, rgba(255, 204, 0, 0.14), transparent 38%);
+}
+
+body.theme-dark .filters-section .filters-eyebrow {
+  color: #cbd5e1;
+}
+
+body.theme-dark .filters-section .filters-title {
+  color: var(--text-strong);
+}
+
 .filters-heading {
   display: flex;
   flex-direction: column;
@@ -1502,6 +1526,37 @@ body.index .interactive-map svg path.non-eu {
   color: #0f172a;
 }
 
+body.theme-dark .filters-section .custom-select {
+  background: linear-gradient(160deg, #1b212b 0%, #11151d 100%);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+body.theme-dark .custom-select .select-toggle {
+  color: #e5e7eb;
+}
+
+body.theme-dark .custom-select .select-toggle::after {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23cbd5e1' d='M1.41 0L6 4.58 10.59 0 12 1.41 6 7.41 0 1.41z'/%3E%3C/svg%3E");
+}
+
+body.theme-dark .custom-select .select-options {
+  background: #0f131a;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.45);
+}
+
+body.theme-dark .custom-select .select-options li {
+  color: #e5e7eb;
+}
+
+body.theme-dark .custom-select .select-options li:hover,
+body.theme-dark .custom-select .select-options li:focus-visible,
+body.theme-dark .custom-select .select-options li[aria-selected="true"] {
+  background: rgba(59, 130, 246, 0.14);
+  color: #e5e7eb;
+}
+
 .custom-select:focus-within .select-toggle,
 .custom-select:hover .select-toggle {
   border-color: #2563eb;
@@ -1511,6 +1566,18 @@ body.index .interactive-map svg path.non-eu {
 .filters-section input.filter-search-input::placeholder {
   color: #718096;
   font-weight: 500;
+}
+
+body.theme-dark .filters-section input.filter-search-input {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: linear-gradient(135deg, #1a1f27 0%, #0f1218 100%);
+  color: #e5e7eb;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='none' stroke='%23cbd5e1' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm10 2-4.35-4.35'/%3E%3C/svg%3E");
+}
+
+body.theme-dark .filters-section input.filter-search-input::placeholder {
+  color: #cbd5e1;
 }
 
 .filter-reset {
@@ -1530,6 +1597,14 @@ body.index .interactive-map svg path.non-eu {
   transform: translateY(-1px);
 }
 
+body.theme-dark .filter-reset {
+  color: #cbd5e1;
+}
+
+body.theme-dark .filter-reset:hover {
+  color: #93c5fd;
+}
+
 /* filter-chips styling */
 .topic-filter {
   margin-top: 1.2rem;
@@ -1543,6 +1618,10 @@ body.index .interactive-map svg path.non-eu {
   color: #5a6f8a;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+}
+
+body.theme-dark .topic-filter .filter-eyebrow {
+  color: #cbd5e1;
 }
 
 .topic-filter .filter-chips {
@@ -1568,12 +1647,26 @@ body.index .interactive-map svg path.non-eu {
   backdrop-filter: blur(2px);
 }
 
+body.theme-dark .filter-chip {
+  background: rgba(59, 130, 246, 0.16);
+  color: #dbeafe;
+  border: 1px solid rgba(59, 130, 246, 0.32);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+
 .filter-chip:hover,
 .filter-chip.active {
   background: var(--eu-blue);
   color: #ffffff;
   transform: translateY(-2px);
   box-shadow: 0 12px 28px rgba(0, 51, 153, 0.28);
+}
+
+body.theme-dark .filter-chip:hover,
+body.theme-dark .filter-chip.active {
+  background: linear-gradient(120deg, #2563eb, #1d4ed8);
+  color: #f8fafc;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
 }
 
 .filter-chip::before {
@@ -1589,6 +1682,11 @@ body.index .interactive-map svg path.non-eu {
   mask-position: center;
   mask-size: 14px;
   background-color: #1d4ed8;
+}
+
+body.theme-dark .filter-chip::before {
+  background-color: #93c5fd;
+  background: rgba(147, 197, 253, 0.18);
 }
 
 .filter-chip[data-topic="high-recognition"]::before {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,6 +4,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
   const body = document.body;
 
+  const SUN_ICON = `
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="18" height="18">
+      <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4V2m0 20v-2m8-8h2M2 12h2m12.95-6.95 1.42-1.42M7.05 18.95l-1.42 1.42m12.72 0-1.42-1.42M7.05 5.05 5.63 3.63M12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8Z" />
+    </svg>
+  `;
+
+  const MOON_ICON = `
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="18" height="18">
+      <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z" />
+    </svg>
+  `;
+
   function applyTheme(theme) {
     const isDark = theme === 'dark';
     body.classList.toggle('theme-dark', isDark);
@@ -12,12 +24,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const label = document.querySelector('.theme-toggle__label');
     if (label) {
-      label.textContent = isDark ? 'Donker' : 'Licht';
+      label.textContent = isDark ? 'Dark' : 'Light';
+    }
+    const icon = document.querySelector('.theme-toggle__icon');
+    if (icon) {
+      icon.innerHTML = isDark ? MOON_ICON : SUN_ICON;
     }
     const toggle = document.querySelector('.theme-toggle');
     if (toggle) {
       toggle.setAttribute('aria-pressed', String(isDark));
-      toggle.setAttribute('aria-label', isDark ? 'Schakel naar lichte modus' : 'Schakel naar donkere modus');
+      toggle.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
     }
   }
 
@@ -38,8 +54,8 @@ document.addEventListener('DOMContentLoaded', () => {
     toggle.type = 'button';
     toggle.className = 'theme-toggle';
     toggle.innerHTML = `
-      <span class="theme-toggle__icon" aria-hidden="true">☀️</span>
-      <span class="theme-toggle__label">Licht</span>
+      <span class="theme-toggle__icon" aria-hidden="true">${SUN_ICON}</span>
+      <span class="theme-toggle__label">Light</span>
     `;
 
     toggle.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- change the theme toggle to English labels with monochrome sun and moon icons
- refresh dark theme palette to charcoal tones and adjust hero/compare backgrounds
- add a modern dark gradient treatment for the filters section and controls

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69414eb46c808320890289924587db4e)