### PR TITLE
Improve filters styling and dark mode maps

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -197,9 +197,9 @@ a {
 }
 
 .page-main {
-  max-width: 1120px;
+  max-width: var(--max-width);
   margin: 0 auto;
-  padding: 3rem 1.5rem 4rem;
+  padding: 3rem 1.25rem 4rem;
 }
 
 .page-intro h1 {
@@ -619,9 +619,9 @@ body.theme-dark .theme-toggle {
 }
 
 body.theme-light .theme-toggle {
-  background: rgba(15, 23, 42, 0.06);
-  border-color: rgba(15, 23, 42, 0.08);
-  color: #0f172a;
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.35);
+  color: #f8fafc;
 }
 
 .site-footer {
@@ -1292,6 +1292,33 @@ body.index .interactive-map svg path.non-eu {
   stroke: rgba(255, 255, 255, 0.8);
 }
 
+body.theme-dark .overview-map {
+  background: linear-gradient(145deg, #1f252f 0%, #141821 42%, #0d0f15 100%);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.45);
+}
+
+body.theme-dark.page-country .interactive-map,
+body.theme-dark .page-country .interactive-map {
+  background: radial-gradient(circle at 30% 20%, rgba(255,255,255,0.08), rgba(255,255,255,0.02) 45%),
+              radial-gradient(circle at 80% 26%, rgba(255,255,255,0.06), rgba(255,255,255,0.02) 50%),
+              rgba(255,255,255,0.03);
+  border: none;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+
+body.theme-dark .page-country .interactive-map svg path {
+  stroke: rgba(226, 232, 240, 0.8);
+}
+
+body.theme-dark .page-country .interactive-map svg path.eu-member {
+  fill: rgba(82, 104, 140, 0.65);
+}
+
+body.theme-dark .page-country .interactive-map svg path.non-eu {
+  stroke: rgba(255, 255, 255, 0.8);
+}
+
 /* Countries page filter section */
 
 .page-countries .filters-section {
@@ -1316,7 +1343,7 @@ body.index .interactive-map svg path.non-eu {
 }
 
 .filters-shell {
-  background: linear-gradient(180deg, #f7faff 0%, #f4f8fe 100%);
+  background: linear-gradient(170deg, #f6f8fb 0%, #eef2f7 100%);
   border: 1px solid #e4e8ed;
   border-radius: 16px;
   padding: 1.25rem 1.5rem;
@@ -1334,8 +1361,8 @@ body.index .interactive-map svg path.non-eu {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 12% 20%, rgba(0, 51, 153, 0.08), transparent 42%),
-              radial-gradient(circle at 86% 28%, rgba(255, 204, 0, 0.14), transparent 40%);
+  background: radial-gradient(circle at 12% 20%, rgba(44, 48, 58, 0.14), transparent 42%),
+              radial-gradient(circle at 86% 28%, rgba(44, 48, 58, 0.12), transparent 40%);
   pointer-events: none;
   z-index: 0;
 }
@@ -1425,10 +1452,16 @@ body.theme-dark .filters-section .filters-title {
   flex-wrap: wrap;
 }
 
+.filters-section .filter-search {
+  position: relative;
+  width: 100%;
+  max-width: 320px;
+}
+
 
 
 .filters-section input.filter-search-input {
-  padding: 0.65rem 1rem 0.65rem 2.75rem;
+  padding: 0.65rem 1rem 0.65rem 2.9rem;
   border-radius: 999px;
   border: 1px solid #e4e8ed;
   background: #ffffff;
@@ -1438,15 +1471,22 @@ body.theme-dark .filters-section .filters-title {
   line-height: 1.4;
   box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
   width: 100%;
-  max-width: 320px;
   position: relative;
+  background-image: none;
 }
 
-.filters-section input.filter-search-input {
+.filters-section .filter-search::before {
+  content: "";
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  width: 18px;
+  height: 18px;
   background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='none' stroke='%23003399' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm10 2-4.35-4.35'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: 1rem center;
   background-size: 18px;
+  transform: translateY(-50%);
+  pointer-events: none;
 }
 
 .filters-section .custom-select {
@@ -1573,6 +1613,9 @@ body.theme-dark .filters-section input.filter-search-input {
   background: linear-gradient(135deg, #1a1f27 0%, #0f1218 100%);
   color: #e5e7eb;
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+body.theme-dark .filters-section .filter-search::before {
   background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='none' stroke='%23cbd5e1' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm10 2-4.35-4.35'/%3E%3C/svg%3E");
 }
 

--- a/countries.html
+++ b/countries.html
@@ -51,12 +51,14 @@
           <div class="filters-controls">
             <div class="filters-inputs">
               <!-- Zoekveld -->
-              <input
-                type="text"
-                class="filter-search-input"
-                placeholder="Search countries…"
-                aria-label="Search countries"
-              >
+              <div class="filter-search">
+                <input
+                  type="text"
+                  class="filter-search-input"
+                  placeholder="Search countries…"
+                  aria-label="Search countries"
+                >
+              </div>
               <!-- Regio-filter -->
               <div class="custom-select region-select-wrapper" data-selected="">
                 <button type="button" class="select-toggle region-select-toggle" aria-haspopup="listbox" aria-expanded="false">


### PR DESCRIPTION
## Summary
- increase visibility of the theme toggle in light mode and align page spacing with other sections
- restyle the countries filter card with an anthracite accent and stabilize the search icon rendering
- refresh country map styling in dark mode to mirror the homepage presentation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941519316288320b86a874e69159065)