### PR TITLE
Adjust filter panel gradients for light and dark modes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1343,7 +1343,7 @@ body.theme-dark .page-country .interactive-map svg path.non-eu {
 }
 
 .filters-shell {
-  background: linear-gradient(170deg, #f6f8fb 0%, #eef2f7 100%);
+  background: linear-gradient(170deg, #f7f8fb 0%, #e8edf5 100%);
   border: 1px solid #e4e8ed;
   border-radius: 16px;
   padding: 1.25rem 1.5rem;
@@ -1361,8 +1361,8 @@ body.theme-dark .page-country .interactive-map svg path.non-eu {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 12% 20%, rgba(44, 48, 58, 0.14), transparent 42%),
-              radial-gradient(circle at 86% 28%, rgba(44, 48, 58, 0.12), transparent 40%);
+  background: radial-gradient(circle at 14% 22%, rgba(165, 184, 213, 0.24), transparent 44%),
+              radial-gradient(circle at 84% 30%, rgba(132, 167, 214, 0.22), transparent 42%);
   pointer-events: none;
   z-index: 0;
 }
@@ -1373,14 +1373,14 @@ body.theme-dark .page-country .interactive-map svg path.non-eu {
 }
 
 body.theme-dark .filters-shell {
-  background: linear-gradient(145deg, #1f252f 0%, #141821 42%, #0d0f15 100%);
+  background: linear-gradient(145deg, #0c1016 0%, #101722 42%, #0a0f18 100%);
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: 0 18px 38px rgba(0, 0, 0, 0.45);
 }
 
 body.theme-dark .filters-shell::after {
-  background: radial-gradient(circle at 15% 22%, rgba(59, 130, 246, 0.12), transparent 42%),
-              radial-gradient(circle at 88% 24%, rgba(255, 204, 0, 0.14), transparent 38%);
+  background: radial-gradient(circle at 15% 22%, rgba(59, 130, 246, 0.2), transparent 42%),
+              radial-gradient(circle at 88% 24%, rgba(96, 165, 250, 0.16), transparent 38%);
 }
 
 body.theme-dark .filters-section .filters-eyebrow {


### PR DESCRIPTION
## Summary
- update the countries filter shell gradients to use softer greys and blues in light mode
- refresh dark mode panel gradient to a black/anthracite base with blue highlights

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941549303508320b141917767b2ea2f)