### PR TITLE
Add topic exclusions to country filters

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -380,16 +380,30 @@ document.addEventListener('DOMContentLoaded', () => {
       .map(chip => chip.dataset.topic)
       .filter(Boolean);
 
+    const topicExclusions = {
+      'high-recognition': new Set(['ee', 'fr']),
+      'strict-policy': new Set(['gr', 'it', 'lv', 'lt']),
+      'labour-migration': new Set(['at', 'hr', 'ro', 'dk', 'fi', 'ee', 'lt', 'hu']),
+      'humanitarian-focus': new Set(['fr', 'es', 'fi', 'si', 'hr', 'ro', 'it'])
+    };
+
+    const isExcludedByTopic = cardId =>
+      activeTopics.some(topic => topicExclusions[topic]?.has(cardId));
+
     countryCards.forEach(card => {
       const name = (card.querySelector('h2')?.textContent || '').toLowerCase();
       const cardRegion = (card.dataset.region || '').toLowerCase();
       const cardTopics = (card.dataset.topic || '').split(/\s+/).filter(Boolean);
+      const cardId = (card.id || '').toLowerCase();
 
       const matchesSearch = !searchTerm || name.includes(searchTerm);
       const matchesRegion = !regionValue || cardRegion === regionValue;
       const matchesTopics = activeTopics.every(topic => cardTopics.includes(topic));
+      const excluded = isExcludedByTopic(cardId);
 
-      card.style.display = matchesSearch && matchesRegion && matchesTopics ? '' : 'none';
+      card.style.display = matchesSearch && matchesRegion && matchesTopics && !excluded
+        ? ''
+        : 'none';
     });
   }
 


### PR DESCRIPTION
## Summary
- add per-topic exclusion sets so specified countries are hidden when their topics are selected

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694176d0d5308320b622e3513ee79fcb)