### PR TITLE
Adjust dark theme hover styling for country cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -869,6 +869,11 @@ body.theme-light .hero-eyebrow {
   box-shadow: 0 14px 32px rgba(37, 99, 235, 0.12);
 }
 
+body.theme-dark .country-card:hover {
+  border-color: rgba(229, 231, 235, 0.6);
+  box-shadow: 0 14px 32px rgba(255, 255, 255, 0.14);
+}
+
 .country-card h2 {
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- add dark-theme-specific hover styling for country cards to use light accents instead of blue
- keep existing light theme hover behavior unchanged

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69418818cbfc83209bf5a25682b84d97)