### PR TITLE
Restyle country cards with gradient backgrounds

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -455,10 +455,20 @@ a {
 }
 
 .country-section-card {
-  background: #ffffff;
+  background: radial-gradient(circle at 26% 18%, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04) 46%),
+    radial-gradient(circle at 82% 22%, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03) 50%),
+    linear-gradient(145deg, #10253f, #0c1b31 52%, #0a1426);
   border-radius: 1.5rem;
   padding: 1.75rem 2rem;
-  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+  border: none;
+  box-shadow: 0 18px 46px rgba(0, 0, 0, 0.28);
+}
+
+body.theme-light .country-section-card {
+  background: radial-gradient(circle at 26% 18%, rgba(37, 99, 235, 0.12), rgba(255, 255, 255, 0.75) 48%),
+    radial-gradient(circle at 82% 22%, rgba(59, 130, 246, 0.1), rgba(255, 255, 255, 0.75) 52%),
+    #ffffff;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
 }
 
 .country-section-tag {


### PR DESCRIPTION
## Summary
- replace country section cards' solid fills with gradient ombre styling inspired by the homepage
- remove hard borders from country cards and adjust shadows for light and dark themes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941abce773c8320b0f4ed383554f668)