### PR TITLE
Lighten dark mode card backgrounds

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -66,8 +66,8 @@ body.theme-dark {
   --bg-page: #121416;
   --bg-surface-dark: #0f223e;
   --bg-surface-elevated: #132b4f;
-  --bg-light: #1a1f27;
-  --bg-light-soft: #1f2530;
+  --bg-light: #222b36;
+  --bg-light-soft: #263143;
 
   --text-main: #e5e7eb;
   --text-muted: #cbd5e1;


### PR DESCRIPTION
## Summary
- lighten dark theme surface variables so cards appear lighter in dark mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941ac11ee688320a273620891c5be9c)