### PR TITLE
Fix Portugal flag on country page

### DIFF
--- a/countries/portugal.html
+++ b/countries/portugal.html
@@ -29,7 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-italy" role="img" aria-label="Flag of Italy"></span>
+          <span class="country-flag flag-portugal" role="img" aria-label="Flag of Portugal"></span>
           <h1>Portugal</h1>
         </div>
         <p>


### PR DESCRIPTION
## Summary
- correct the country flag icon shown on the Portugal page to use the Portugal flag and aria label

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941b7397ee083208f64d5f1719fbdd5)