### PR TITLE
Ensure non-EU borders are white on dark country maps

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1449,7 +1449,7 @@ body.theme-dark .page-country .interactive-map svg path.eu-member {
 }
 
 body.theme-dark .page-country .interactive-map svg path.non-eu {
-  stroke: rgba(255, 255, 255, 0.8);
+  stroke: #ffffff;
 }
 
 /* Countries page filter section */


### PR DESCRIPTION
## Summary
- brighten non-EU country borders on dark-themed country map views so boundaries stay visible

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941baa0b0348320bfdd64d50ea71ab6)