### PR TITLE
Use image flags and improve map visibility

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -280,72 +280,18 @@ body.compare-page {
    - Any accidental text inside stays hidden (e.g., "FR")
    - Emoji comes only from ::before */
 .country-flag {
-  width: 42px;
-  height: 28px;
-  border-radius: 6px;
+  width: 28px;
+  height: 20px;
+  border-radius: 4px;
   border: 1px solid rgba(0, 0, 0, 0.06);
-  overflow: hidden;
-  position: relative;
-
   box-shadow:
     0 2px 6px rgba(0, 0, 0, 0.12),
     0 1px 2px rgba(0, 0, 0, 0.08);
-
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  /* Hide any inner text */
-  color: transparent;
-  font-size: 0;
-  line-height: 0;
-
-  font-family: "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji", "Twemoji Mozilla", sans-serif;
-  user-select: none;
-  aspect-ratio: 3 / 2;
+  object-fit: cover;
   flex: 0 0 auto;
+  display: inline-block;
+  background: #f8fafc;
 }
-
-.country-flag::before {
-  content: var(--flag-emoji, "");
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.35rem;
-  line-height: 1;
-  color: initial;
-}
-
-/* Emoji mappings */
-.flag-austria { --flag-emoji: "🇦🇹"; }
-.flag-belgium { --flag-emoji: "🇧🇪"; }
-.flag-bulgaria { --flag-emoji: "🇧🇬"; }
-.flag-croatia { --flag-emoji: "🇭🇷"; }
-.flag-cyprus { --flag-emoji: "🇨🇾"; }
-.flag-czechia { --flag-emoji: "🇨🇿"; }
-.flag-denmark { --flag-emoji: "🇩🇰"; }
-.flag-estonia { --flag-emoji: "🇪🇪"; }
-.flag-finland { --flag-emoji: "🇫🇮"; }
-.flag-france { --flag-emoji: "🇫🇷"; }
-.flag-germany { --flag-emoji: "🇩🇪"; }
-.flag-greece { --flag-emoji: "🇬🇷"; }
-.flag-hungary { --flag-emoji: "🇭🇺"; }
-.flag-ireland { --flag-emoji: "🇮🇪"; }
-.flag-italy { --flag-emoji: "🇮🇹"; }
-.flag-latvia { --flag-emoji: "🇱🇻"; }
-.flag-lithuania { --flag-emoji: "🇱🇹"; }
-.flag-luxembourg { --flag-emoji: "🇱🇺"; }
-.flag-malta { --flag-emoji: "🇲🇹"; }
-.flag-netherlands { --flag-emoji: "🇳🇱"; }
-.flag-poland { --flag-emoji: "🇵🇱"; }
-.flag-portugal { --flag-emoji: "🇵🇹"; }
-.flag-romania { --flag-emoji: "🇷🇴"; }
-.flag-slovakia { --flag-emoji: "🇸🇰"; }
-.flag-slovenia { --flag-emoji: "🇸🇮"; }
-.flag-spain { --flag-emoji: "🇪🇸"; }
-.flag-sweden { --flag-emoji: "🇸🇪"; }
 
 /* ========================================
    Country overview + map
@@ -410,15 +356,17 @@ body.theme-dark .page-country .interactive-map {
   height: auto;
 }
 
-.interactive-map svg path {
+.interactive-map svg path[id] {
   fill: none;
-  stroke: var(--map-stroke-eu);
-  stroke-width: 0.4;
+  stroke: rgba(255, 255, 255, 0.35);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
   transition: fill var(--transition-fast), stroke var(--transition-fast), stroke-width var(--transition-fast);
 }
 
 .interactive-map svg path.eu-member {
   fill: #c3c9da;
+  stroke: rgba(255, 255, 255, 0.45);
 }
 
 body.theme-dark .page-country .interactive-map svg path.eu-member {
@@ -427,7 +375,7 @@ body.theme-dark .page-country .interactive-map svg path.eu-member {
 
 .interactive-map svg path.non-eu {
   fill: transparent;
-  stroke: var(--map-stroke-non-eu);
+  stroke: rgba(255, 255, 255, 0.25);
 }
 
 .interactive-map svg path.is-clickable {
@@ -438,6 +386,10 @@ body.theme-dark .page-country .interactive-map svg path.eu-member {
   fill: var(--eu-gold);
   stroke: #0f172a;
   stroke-width: 0.8;
+}
+
+.interactive-map svg path.is-highlighted {
+  stroke-width: 2;
 }
 
 .interactive-map .map-tooltip {

--- a/assets/flags/at.svg
+++ b/assets/flags/at.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇦🇹</text>
+</svg>

--- a/assets/flags/be.svg
+++ b/assets/flags/be.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇧🇪</text>
+</svg>

--- a/assets/flags/bg.svg
+++ b/assets/flags/bg.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇧🇬</text>
+</svg>

--- a/assets/flags/cy.svg
+++ b/assets/flags/cy.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇨🇾</text>
+</svg>

--- a/assets/flags/cz.svg
+++ b/assets/flags/cz.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇨🇿</text>
+</svg>

--- a/assets/flags/de.svg
+++ b/assets/flags/de.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇩🇪</text>
+</svg>

--- a/assets/flags/dk.svg
+++ b/assets/flags/dk.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇩🇰</text>
+</svg>

--- a/assets/flags/ee.svg
+++ b/assets/flags/ee.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇪🇪</text>
+</svg>

--- a/assets/flags/es.svg
+++ b/assets/flags/es.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇪🇸</text>
+</svg>

--- a/assets/flags/fi.svg
+++ b/assets/flags/fi.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇫🇮</text>
+</svg>

--- a/assets/flags/fr.svg
+++ b/assets/flags/fr.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇫🇷</text>
+</svg>

--- a/assets/flags/gr.svg
+++ b/assets/flags/gr.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇬🇷</text>
+</svg>

--- a/assets/flags/hr.svg
+++ b/assets/flags/hr.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇭🇷</text>
+</svg>

--- a/assets/flags/hu.svg
+++ b/assets/flags/hu.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇭🇺</text>
+</svg>

--- a/assets/flags/ie.svg
+++ b/assets/flags/ie.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇮🇪</text>
+</svg>

--- a/assets/flags/it.svg
+++ b/assets/flags/it.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇮🇹</text>
+</svg>

--- a/assets/flags/lt.svg
+++ b/assets/flags/lt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇱🇹</text>
+</svg>

--- a/assets/flags/lu.svg
+++ b/assets/flags/lu.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇱🇺</text>
+</svg>

--- a/assets/flags/lv.svg
+++ b/assets/flags/lv.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇱🇻</text>
+</svg>

--- a/assets/flags/mt.svg
+++ b/assets/flags/mt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇲🇹</text>
+</svg>

--- a/assets/flags/nl.svg
+++ b/assets/flags/nl.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇳🇱</text>
+</svg>

--- a/assets/flags/pl.svg
+++ b/assets/flags/pl.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇵🇱</text>
+</svg>

--- a/assets/flags/pt.svg
+++ b/assets/flags/pt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇵🇹</text>
+</svg>

--- a/assets/flags/ro.svg
+++ b/assets/flags/ro.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇷🇴</text>
+</svg>

--- a/assets/flags/se.svg
+++ b/assets/flags/se.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇸🇪</text>
+</svg>

--- a/assets/flags/si.svg
+++ b/assets/flags/si.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇸🇮</text>
+</svg>

--- a/assets/flags/sk.svg
+++ b/assets/flags/sk.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="28" viewBox="0 0 42 28" role="img" aria-label="Flag">
+  <rect width="42" height="28" rx="4" ry="4" fill="#ffffff"/>
+  <text x="21" y="20" font-size="18" text-anchor="middle">🇸🇰</text>
+</svg>

--- a/countries.html
+++ b/countries.html
@@ -92,7 +92,7 @@
 
         <!-- Austria -->
         <a href="countries/austria.html" id="at" class="country-card" data-region="western" data-topic="strict-policy labour-migration">
-          <span class="country-flag flag-austria" role="img" aria-label="Flag of Austria"></span>
+          <img class="country-flag" src="assets/flags/at.svg" alt="Flag of Austria" width="28" height="20" />
           <h2>Austria</h2>
           <p>Schengen member balancing humanitarian duties with firm border controls.</p>
           <span class="country-more">View profile →</span>
@@ -100,7 +100,7 @@
 
         <!-- Belgium -->
         <a href="countries/belgium.html" id="be" class="country-card" data-region="western" data-topic="high-recognition labour-migration">
-          <span class="country-flag flag-belgium" role="img" aria-label="Flag of Belgium"></span>
+          <img class="country-flag" src="assets/flags/be.svg" alt="Flag of Belgium" width="28" height="20" />
           <h2>Belgium</h2>
           <p>Federal system coordinating asylum reception across regions and communities.</p>
           <span class="country-more">View profile →</span>
@@ -108,7 +108,7 @@
 
         <!-- Bulgaria -->
         <a href="countries/bulgaria.html" id="bg" class="country-card" data-region="eastern" data-topic="strict-policy">
-          <span class="country-flag flag-bulgaria" role="img" aria-label="Flag of Bulgaria"></span>
+          <img class="country-flag" src="assets/flags/bg.svg" alt="Flag of Bulgaria" width="28" height="20" />
           <h2>Bulgaria</h2>
           <p>Border state on the EU’s external frontier with a focus on security and returns.</p>
           <span class="country-more">View profile →</span>
@@ -116,7 +116,7 @@
 
         <!-- Croatia -->
         <a href="countries/croatia.html" id="hr" class="country-card" data-region="southern" data-topic="labour-migration humanitarian-focus">
-          <span class="country-flag flag-croatia" role="img" aria-label="Flag of Croatia"></span>
+          <img class="country-flag" src="assets/flags/hr.svg" alt="Flag of Croatia" width="28" height="20" />
           <h2>Croatia</h2>
           <p>Newer Schengen member strengthening reception while managing Balkan route flows.</p>
           <span class="country-more">View profile →</span>
@@ -124,7 +124,7 @@
 
         <!-- Cyprus -->
         <a href="countries/cyprus.html" id="cy" class="country-card" data-region="southern" data-topic="high-recognition humanitarian-focus">
-          <span class="country-flag flag-cyprus" role="img" aria-label="Flag of Cyprus"></span>
+          <img class="country-flag" src="assets/flags/cy.svg" alt="Flag of Cyprus" width="28" height="20" />
           <h2>Cyprus</h2>
           <p>Island state facing high asylum pressure relative to population size.</p>
           <span class="country-more">View profile →</span>
@@ -132,7 +132,7 @@
 
         <!-- Czechia -->
         <a href="countries/czechia.html" id="cz" class="country-card" data-region="eastern" data-topic="strict-policy">
-          <span class="country-flag flag-czechia" role="img" aria-label="Flag of Czechia"></span>
+          <img class="country-flag" src="assets/flags/cz.svg" alt="Flag of Czechia" width="28" height="20" />
           <h2>Czechia</h2>
           <p>Central European state prioritising security vetting and temporary protection.</p>
           <span class="country-more">View profile →</span>
@@ -140,7 +140,7 @@
 
         <!-- Denmark -->
         <a href="countries/denmark.html" id="dk" class="country-card" data-region="northern" data-topic="strict-policy labour-migration">
-          <span class="country-flag flag-denmark" role="img" aria-label="Flag of Denmark"></span>
+          <img class="country-flag" src="assets/flags/dk.svg" alt="Flag of Denmark" width="28" height="20" />
           <h2>Denmark</h2>
           <p>Opt-out EU member with restrictive asylum rules and labour migration schemes.</p>
           <span class="country-more">View profile →</span>
@@ -148,7 +148,7 @@
 
         <!-- Estonia -->
         <a href="countries/estonia.html" id="ee" class="country-card" data-region="northern" data-topic="high-recognition labour-migration">
-          <span class="country-flag flag-estonia" role="img" aria-label="Flag of Estonia"></span>
+          <img class="country-flag" src="assets/flags/ee.svg" alt="Flag of Estonia" width="28" height="20" />
           <h2>Estonia</h2>
           <p>Digital-first administration managing migration with streamlined e-services.</p>
           <span class="country-more">View profile →</span>
@@ -156,7 +156,7 @@
 
         <!-- Finland -->
         <a href="countries/finland.html" id="fi" class="country-card" data-region="northern" data-topic="humanitarian-focus labour-migration">
-          <span class="country-flag flag-finland" role="img" aria-label="Flag of Finland"></span>
+          <img class="country-flag" src="assets/flags/fi.svg" alt="Flag of Finland" width="28" height="20" />
           <h2>Finland</h2>
           <p>Nordic system emphasising protection standards and orderly labour pathways.</p>
           <span class="country-more">View profile →</span>
@@ -164,7 +164,7 @@
 
         <!-- France -->
         <a href="countries/france.html" id="fr" class="country-card" data-region="western" data-topic="humanitarian-focus high-recognition">
-          <span class="country-flag flag-france" role="img" aria-label="Flag of France"></span>
+          <img class="country-flag" src="assets/flags/fr.svg" alt="Flag of France" width="28" height="20" />
           <h2>France</h2>
           <p>Major destination balancing humanitarian reception with integration priorities.</p>
           <span class="country-more">View profile →</span>
@@ -172,7 +172,7 @@
 
         <!-- Germany -->
         <a href="countries/germany.html" id="de" class="country-card" data-region="western" data-topic="labour-migration high-recognition">
-          <span class="country-flag flag-germany" role="img" aria-label="Flag of Germany"></span>
+          <img class="country-flag" src="assets/flags/de.svg" alt="Flag of Germany" width="28" height="20" />
           <h2>Germany</h2>
           <p>Largest EU recipient of protection seekers with reformed skilled migration laws.</p>
           <span class="country-more">View profile →</span>
@@ -180,7 +180,7 @@
 
         <!-- Greece -->
         <a href="countries/greece.html" id="gr" class="country-card" data-region="southern" data-topic="strict-policy">
-          <span class="country-flag flag-greece" role="img" aria-label="Flag of Greece"></span>
+          <img class="country-flag" src="assets/flags/gr.svg" alt="Flag of Greece" width="28" height="20" />
           <h2>Greece</h2>
           <p>Frontline state managing Aegean arrivals through EU-Türkiye cooperation.</p>
           <span class="country-more">View profile →</span>
@@ -188,7 +188,7 @@
 
         <!-- Hungary -->
         <a href="countries/hungary.html" id="hu" class="country-card" data-region="eastern" data-topic="strict-policy labour-migration">
-          <span class="country-flag flag-hungary" role="img" aria-label="Flag of Hungary"></span>
+          <img class="country-flag" src="assets/flags/hu.svg" alt="Flag of Hungary" width="28" height="20" />
           <h2>Hungary</h2>
           <p>Implements fence-based border controls and limited asylum access points.</p>
           <span class="country-more">View profile →</span>
@@ -196,7 +196,7 @@
 
         <!-- Ireland -->
         <a href="countries/ireland.html" id="ie" class="country-card" data-region="western" data-topic="humanitarian-focus">
-          <span class="country-flag flag-ireland" role="img" aria-label="Flag of Ireland"></span>
+          <img class="country-flag" src="assets/flags/ie.svg" alt="Flag of Ireland" width="28" height="20" />
           <h2>Ireland</h2>
           <p>Common Travel Area member overhauling reception and direct provision systems.</p>
           <span class="country-more">View profile →</span>
@@ -204,7 +204,7 @@
 
         <!-- Italy -->
         <a href="countries/italy.html" id="it" class="country-card" data-region="southern" data-topic="strict-policy humanitarian-focus labour-migration">
-          <span class="country-flag flag-italy" role="img" aria-label="Flag of Italy"></span>
+          <img class="country-flag" src="assets/flags/it.svg" alt="Flag of Italy" width="28" height="20" />
           <h2>Italy</h2>
           <p>
             Key entry point on the Central Mediterranean route with
@@ -215,7 +215,7 @@
 
         <!-- Latvia -->
         <a href="countries/latvia.html" id="lv" class="country-card" data-region="northern" data-topic="strict-policy">
-          <span class="country-flag flag-latvia" role="img" aria-label="Flag of Latvia"></span>
+          <img class="country-flag" src="assets/flags/lv.svg" alt="Flag of Latvia" width="28" height="20" />
           <h2>Latvia</h2>
           <p>Border state emphasising security screenings and rapid response capacity.</p>
           <span class="country-more">View profile →</span>
@@ -223,7 +223,7 @@
 
         <!-- Lithuania -->
         <a href="countries/lithuania.html" id="lt" class="country-card" data-region="eastern" data-topic="strict-policy labour-migration">
-          <span class="country-flag flag-lithuania" role="img" aria-label="Flag of Lithuania"></span>
+          <img class="country-flag" src="assets/flags/lt.svg" alt="Flag of Lithuania" width="28" height="20" />
           <h2>Lithuania</h2>
           <p>Developing asylum infrastructure after recent hybrid border pressures.</p>
           <span class="country-more">View profile →</span>
@@ -231,7 +231,7 @@
 
         <!-- Luxembourg -->
         <a href="countries/luxembourg.html" id="lu" class="country-card" data-region="western" data-topic="high-recognition humanitarian-focus">
-          <span class="country-flag flag-luxembourg" role="img" aria-label="Flag of Luxembourg"></span>
+          <img class="country-flag" src="assets/flags/lu.svg" alt="Flag of Luxembourg" width="28" height="20" />
           <h2>Luxembourg</h2>
           <p>Small state with coordinated reception services and multilingual integration.</p>
           <span class="country-more">View profile →</span>
@@ -239,7 +239,7 @@
 
         <!-- Malta -->
         <a href="countries/malta.html" id="mt" class="country-card" data-region="southern" data-topic="high-recognition humanitarian-focus">
-          <span class="country-flag flag-malta" role="img" aria-label="Flag of Malta"></span>
+          <img class="country-flag" src="assets/flags/mt.svg" alt="Flag of Malta" width="28" height="20" />
           <h2>Malta</h2>
           <p>Mediterranean island managing boat arrivals with EU burden-sharing calls.</p>
           <span class="country-more">View profile →</span>
@@ -247,7 +247,7 @@
 
         <!-- Netherlands -->
         <a href="countries/netherlands.html" id="nl" class="country-card" data-region="western" data-topic="labour-migration high-recognition">
-          <span class="country-flag flag-netherlands" role="img" aria-label="Flag of the Netherlands"></span>
+          <img class="country-flag" src="assets/flags/nl.svg" alt="Flag of the Netherlands" width="28" height="20" />
           <h2>Netherlands</h2>
           <p>Focuses on skilled migration, civic integration, and decentralised reception.</p>
           <span class="country-more">View profile →</span>
@@ -255,7 +255,7 @@
 
         <!-- Poland -->
         <a href="countries/poland.html" id="pl" class="country-card" data-region="eastern" data-topic="strict-policy">
-          <span class="country-flag flag-poland" role="img" aria-label="Flag of Poland"></span>
+          <img class="country-flag" src="assets/flags/pl.svg" alt="Flag of Poland" width="28" height="20" />
           <h2>Poland</h2>
           <p>Hosts millions under temporary protection while reinforcing eastern borders.</p>
           <span class="country-more">View profile →</span>
@@ -263,7 +263,7 @@
 
         <!-- Portugal -->
         <a href="countries/portugal.html" id="pt" class="country-card" data-region="southern" data-topic="high-recognition labour-migration humanitarian-focus">
-          <span class="country-flag flag-portugal" role="img" aria-label="Flag of Portugal"></span>
+          <img class="country-flag" src="assets/flags/pt.svg" alt="Flag of Portugal" width="28" height="20" />
           <h2>Portugal</h2>
           <p>Proactive recruitment of workers paired with inclusive integration policies.</p>
           <span class="country-more">View profile →</span>
@@ -271,7 +271,7 @@
 
         <!-- Romania -->
         <a href="countries/romania.html" id="ro" class="country-card" data-region="eastern" data-topic="humanitarian-focus labour-migration">
-          <span class="country-flag flag-romania" role="img" aria-label="Flag of Romania"></span>
+          <img class="country-flag" src="assets/flags/ro.svg" alt="Flag of Romania" width="28" height="20" />
           <h2>Romania</h2>
           <p>Key hub for Ukrainian displacement response and managed labour inflows.</p>
           <span class="country-more">View profile →</span>
@@ -279,7 +279,7 @@
 
         <!-- Slovakia -->
         <a href="countries/slovakia.html" id="sk" class="country-card" data-region="eastern" data-topic="strict-policy">
-          <span class="country-flag flag-slovakia" role="img" aria-label="Flag of Slovakia"></span>
+          <img class="country-flag" src="assets/flags/sk.svg" alt="Flag of Slovakia" width="28" height="20" />
           <h2>Slovakia</h2>
           <p>Border management emphasises security cooperation and temporary protection.</p>
           <span class="country-more">View profile →</span>
@@ -287,7 +287,7 @@
 
         <!-- Slovenia -->
         <a href="countries/slovenia.html" id="si" class="country-card" data-region="southern" data-topic="humanitarian-focus">
-          <span class="country-flag flag-slovenia" role="img" aria-label="Flag of Slovenia"></span>
+          <img class="country-flag" src="assets/flags/si.svg" alt="Flag of Slovenia" width="28" height="20" />
           <h2>Slovenia</h2>
           <p>Bridges Balkan and Alpine routes with solidarity-based relocation pledges.</p>
           <span class="country-more">View profile →</span>
@@ -295,7 +295,7 @@
 
         <!-- Spain -->
         <a href="countries/spain.html" id="es" class="country-card" data-region="southern" data-topic="high-recognition humanitarian-focus labour-migration">
-          <span class="country-flag flag-spain" role="img" aria-label="Flag of Spain"></span>
+          <img class="country-flag" src="assets/flags/es.svg" alt="Flag of Spain" width="28" height="20" />
           <h2>Spain</h2>
           <p>
             Spain has been a member of the European Union since January 1, 1986.
@@ -305,7 +305,7 @@
 
         <!-- Sweden -->
         <a href="countries/sweden.html" id="se" class="country-card" data-region="northern" data-topic="high-recognition humanitarian-focus">
-          <span class="country-flag flag-sweden" role="img" aria-label="Flag of Sweden"></span>
+          <img class="country-flag" src="assets/flags/se.svg" alt="Flag of Sweden" width="28" height="20" />
           <h2>Sweden</h2>
           <p>Long-standing refugee destination now tightening rules while supporting integration.</p>
           <span class="country-more">View profile →</span>

--- a/countries/austria.html
+++ b/countries/austria.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-austria" role="img" aria-label="Flag of Austria"></span>
+          <img class="country-flag"
+               src="../assets/flags/at.svg"
+               alt="Flag of Austria"
+               width="28" height="20" />
           <h1>Austria</h1>
         </div>
         <p>

--- a/countries/belgium.html
+++ b/countries/belgium.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-belgium" role="img" aria-label="Flag of Belgium"></span>
+          <img class="country-flag"
+               src="../assets/flags/be.svg"
+               alt="Flag of Belgium"
+               width="28" height="20" />
           <h1>Belgium</h1>
         </div>
         <p>

--- a/countries/bulgaria.html
+++ b/countries/bulgaria.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-bulgaria" role="img" aria-label="Flag of Bulgaria"></span>
+          <img class="country-flag"
+               src="../assets/flags/bg.svg"
+               alt="Flag of Bulgaria"
+               width="28" height="20" />
           <h1>Bulgaria</h1>
         </div>
         <p>

--- a/countries/croatia.html
+++ b/countries/croatia.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-croatia" role="img" aria-label="Flag of Croatia"></span>
+          <img class="country-flag"
+               src="../assets/flags/hr.svg"
+               alt="Flag of Croatia"
+               width="28" height="20" />
           <h1>Croatia</h1>
         </div>
         <p>

--- a/countries/cyprus.html
+++ b/countries/cyprus.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-cyprus" role="img" aria-label="Flag of Cyprus"></span>
+          <img class="country-flag"
+               src="../assets/flags/cy.svg"
+               alt="Flag of Cyprus"
+               width="28" height="20" />
           <h1>Cyprus</h1>
         </div>
         <p>

--- a/countries/czechia.html
+++ b/countries/czechia.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-czechia" role="img" aria-label="Flag of Czechia"></span>
+          <img class="country-flag"
+               src="../assets/flags/cz.svg"
+               alt="Flag of Czechia"
+               width="28" height="20" />
           <h1>Czechia</h1>
         </div>
         <p>

--- a/countries/denmark.html
+++ b/countries/denmark.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-denmark" role="img" aria-label="Flag of Denmark"></span>
+          <img class="country-flag"
+               src="../assets/flags/dk.svg"
+               alt="Flag of Denmark"
+               width="28" height="20" />
           <h1>Denmark</h1>
         </div>
         <p>

--- a/countries/estonia.html
+++ b/countries/estonia.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-estonia" role="img" aria-label="Flag of Estonia"></span>
+          <img class="country-flag"
+               src="../assets/flags/ee.svg"
+               alt="Flag of Estonia"
+               width="28" height="20" />
           <h1>Estonia</h1>
         </div>
         <p>

--- a/countries/finland.html
+++ b/countries/finland.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-finland" role="img" aria-label="Flag of Finland"></span>
+          <img class="country-flag"
+               src="../assets/flags/fi.svg"
+               alt="Flag of Finland"
+               width="28" height="20" />
           <h1>Finland</h1>
         </div>
         <p>

--- a/countries/france.html
+++ b/countries/france.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-france" role="img" aria-label="Flag of France"></span>
+          <img class="country-flag"
+               src="../assets/flags/fr.svg"
+               alt="Flag of France"
+               width="28" height="20" />
           <h1>France</h1>
         </div>
         <p>

--- a/countries/germany.html
+++ b/countries/germany.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-germany" role="img" aria-label="Flag of Germany"></span>
+          <img class="country-flag"
+               src="../assets/flags/de.svg"
+               alt="Flag of Germany"
+               width="28" height="20" />
           <h1>Germany</h1>
         </div>
         <p>

--- a/countries/greece.html
+++ b/countries/greece.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-greece" role="img" aria-label="Flag of Greece"></span>
+          <img class="country-flag"
+               src="../assets/flags/gr.svg"
+               alt="Flag of Greece"
+               width="28" height="20" />
           <h1>Greece</h1>
         </div>
         <p>

--- a/countries/hungary.html
+++ b/countries/hungary.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-hungary" role="img" aria-label="Flag of Hungary"></span>
+          <img class="country-flag"
+               src="../assets/flags/hu.svg"
+               alt="Flag of Hungary"
+               width="28" height="20" />
           <h1>Hungary</h1>
         </div>
         <p>

--- a/countries/ireland.html
+++ b/countries/ireland.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-ireland" role="img" aria-label="Flag of Ireland"></span>
+          <img class="country-flag"
+               src="../assets/flags/ie.svg"
+               alt="Flag of Ireland"
+               width="28" height="20" />
           <h1>Ireland</h1>
         </div>
         <p>

--- a/countries/italy.html
+++ b/countries/italy.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-italy" role="img" aria-label="Flag of Italy"></span>
+          <img class="country-flag"
+               src="../assets/flags/it.svg"
+               alt="Flag of Italy"
+               width="28" height="20" />
           <h1>Italy</h1>
         </div>
         <p>

--- a/countries/latvia.html
+++ b/countries/latvia.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-latvia" role="img" aria-label="Flag of Latvia"></span>
+          <img class="country-flag"
+               src="../assets/flags/lv.svg"
+               alt="Flag of Latvia"
+               width="28" height="20" />
           <h1>Latvia</h1>
         </div>
         <p>

--- a/countries/lithuania.html
+++ b/countries/lithuania.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-lithuania" role="img" aria-label="Flag of Lithuania"></span>
+          <img class="country-flag"
+               src="../assets/flags/lt.svg"
+               alt="Flag of Lithuania"
+               width="28" height="20" />
           <h1>Lithuania</h1>
         </div>
         <p>

--- a/countries/luxembourg.html
+++ b/countries/luxembourg.html
@@ -31,7 +31,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-luxembourg" role="img" aria-label="Flag of Luxembourg"></span>
+          <img class="country-flag"
+               src="../assets/flags/lu.svg"
+               alt="Flag of Luxembourg"
+               width="28" height="20" />
           <h1>Luxembourg</h1>
         </div>
         <p>

--- a/countries/malta.html
+++ b/countries/malta.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-malta" role="img" aria-label="Flag of Malta"></span>
+          <img class="country-flag"
+               src="../assets/flags/mt.svg"
+               alt="Flag of Malta"
+               width="28" height="20" />
           <h1>Malta</h1>
         </div>
         <p>

--- a/countries/netherlands.html
+++ b/countries/netherlands.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-netherlands" role="img" aria-label="Flag of Netherlands"></span>
+          <img class="country-flag"
+               src="../assets/flags/nl.svg"
+               alt="Flag of the Netherlands"
+               width="28" height="20" />
           <h1>Netherlands</h1>
         </div>
         <p>

--- a/countries/poland.html
+++ b/countries/poland.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-poland" role="img" aria-label="Flag of Poland"></span>
+          <img class="country-flag"
+               src="../assets/flags/pl.svg"
+               alt="Flag of Poland"
+               width="28" height="20" />
           <h1>Poland</h1>
         </div>
         <p>

--- a/countries/portugal.html
+++ b/countries/portugal.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-portugal" role="img" aria-label="Flag of Portugal"></span>
+          <img class="country-flag"
+               src="../assets/flags/pt.svg"
+               alt="Flag of Portugal"
+               width="28" height="20" />
           <h1>Portugal</h1>
         </div>
         <p>

--- a/countries/romania.html
+++ b/countries/romania.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-romania" role="img" aria-label="Flag of Romania"></span>
+          <img class="country-flag"
+               src="../assets/flags/ro.svg"
+               alt="Flag of Romania"
+               width="28" height="20" />
           <h1>Romania</h1>
         </div>
         <p>

--- a/countries/slovakia.html
+++ b/countries/slovakia.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-slovakia" role="img" aria-label="Flag of Slovakia"></span>
+          <img class="country-flag"
+               src="../assets/flags/sk.svg"
+               alt="Flag of Slovakia"
+               width="28" height="20" />
           <h1>Slovakia</h1>
         </div>
         <p>

--- a/countries/slovenia.html
+++ b/countries/slovenia.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-slovenia" role="img" aria-label="Flag of Slovenia"></span>
+          <img class="country-flag"
+               src="../assets/flags/si.svg"
+               alt="Flag of Slovenia"
+               width="28" height="20" />
           <h1>Slovenia</h1>
         </div>
         <p>

--- a/countries/spain.html
+++ b/countries/spain.html
@@ -30,7 +30,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-spain" role="img" aria-label="Flag of Spain"></span>
+          <img class="country-flag"
+               src="../assets/flags/es.svg"
+               alt="Flag of Spain"
+               width="28" height="20" />
           <h1>Spain</h1>
         </div>
         <p>

--- a/countries/sweden.html
+++ b/countries/sweden.html
@@ -29,7 +29,10 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <span class="country-flag flag-sweden" role="img" aria-label="Flag of Sweden"></span>
+          <img class="country-flag"
+               src="../assets/flags/se.svg"
+               alt="Flag of Sweden"
+               width="28" height="20" />
           <h1>Sweden</h1>
         </div>
         <p>


### PR DESCRIPTION
## Summary
- replace span-based country flags with local ISO-coded image assets across country cards
- add placeholder SVG flag files for each listed EU member state
- adjust interactive map strokes to ensure EU and non-EU borders remain visible and highlighted

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941cb5aafc48320a64cbf121618407f)