### PR TITLE
Standardize flag styling across country pages

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -280,17 +280,123 @@ body.compare-page {
    - Any accidental text inside stays hidden (e.g., "FR")
    - Emoji comes only from ::before */
 .country-flag {
-  width: 28px;
-  height: 20px;
-  border-radius: 4px;
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  box-shadow:
-    0 2px 6px rgba(0, 0, 0, 0.12),
-    0 1px 2px rgba(0, 0, 0, 0.08);
-  object-fit: cover;
-  flex: 0 0 auto;
   display: inline-block;
-  background: #f8fafc;
+  width: 32px;
+  height: 22px;
+  border-radius: 4px;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  vertical-align: middle;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+
+.country-flag.flag-at {
+  background-image: url("../flags/at.svg");
+}
+
+.country-flag.flag-be {
+  background-image: url("../flags/be.svg");
+}
+
+.country-flag.flag-bg {
+  background-image: url("../flags/bg.svg");
+}
+
+.country-flag.flag-cy {
+  background-image: url("../flags/cy.svg");
+}
+
+.country-flag.flag-cz {
+  background-image: url("../flags/cz.svg");
+}
+
+.country-flag.flag-de {
+  background-image: url("../flags/de.svg");
+}
+
+.country-flag.flag-dk {
+  background-image: url("../flags/dk.svg");
+}
+
+.country-flag.flag-ee {
+  background-image: url("../flags/ee.svg");
+}
+
+.country-flag.flag-es {
+  background-image: url("../flags/es.svg");
+}
+
+.country-flag.flag-fi {
+  background-image: url("../flags/fi.svg");
+}
+
+.country-flag.flag-fr {
+  background-image: url("../flags/fr.svg");
+}
+
+.country-flag.flag-gr {
+  background-image: url("../flags/gr.svg");
+}
+
+.country-flag.flag-hr {
+  background-image: url("../flags/hr.svg");
+}
+
+.country-flag.flag-hu {
+  background-image: url("../flags/hu.svg");
+}
+
+.country-flag.flag-ie {
+  background-image: url("../flags/ie.svg");
+}
+
+.country-flag.flag-it {
+  background-image: url("../flags/it.svg");
+}
+
+.country-flag.flag-lt {
+  background-image: url("../flags/lt.svg");
+}
+
+.country-flag.flag-lu {
+  background-image: url("../flags/lu.svg");
+}
+
+.country-flag.flag-lv {
+  background-image: url("../flags/lv.svg");
+}
+
+.country-flag.flag-mt {
+  background-image: url("../flags/mt.svg");
+}
+
+.country-flag.flag-nl {
+  background-image: url("../flags/nl.svg");
+}
+
+.country-flag.flag-pl {
+  background-image: url("../flags/pl.svg");
+}
+
+.country-flag.flag-pt {
+  background-image: url("../flags/pt.svg");
+}
+
+.country-flag.flag-ro {
+  background-image: url("../flags/ro.svg");
+}
+
+.country-flag.flag-se {
+  background-image: url("../flags/se.svg");
+}
+
+.country-flag.flag-si {
+  background-image: url("../flags/si.svg");
+}
+
+.country-flag.flag-sk {
+  background-image: url("../flags/sk.svg");
 }
 
 /* ========================================

--- a/countries.html
+++ b/countries.html
@@ -92,7 +92,7 @@
 
         <!-- Austria -->
         <a href="countries/austria.html" id="at" class="country-card" data-region="western" data-topic="strict-policy labour-migration">
-          <img class="country-flag" src="assets/flags/at.svg" alt="Flag of Austria" width="28" height="20" />
+          <span class="country-flag flag-at" role="img" aria-label="Flag of Austria"></span>
           <h2>Austria</h2>
           <p>Schengen member balancing humanitarian duties with firm border controls.</p>
           <span class="country-more">View profile →</span>
@@ -100,7 +100,7 @@
 
         <!-- Belgium -->
         <a href="countries/belgium.html" id="be" class="country-card" data-region="western" data-topic="high-recognition labour-migration">
-          <img class="country-flag" src="assets/flags/be.svg" alt="Flag of Belgium" width="28" height="20" />
+          <span class="country-flag flag-be" role="img" aria-label="Flag of Belgium"></span>
           <h2>Belgium</h2>
           <p>Federal system coordinating asylum reception across regions and communities.</p>
           <span class="country-more">View profile →</span>
@@ -108,7 +108,7 @@
 
         <!-- Bulgaria -->
         <a href="countries/bulgaria.html" id="bg" class="country-card" data-region="eastern" data-topic="strict-policy">
-          <img class="country-flag" src="assets/flags/bg.svg" alt="Flag of Bulgaria" width="28" height="20" />
+          <span class="country-flag flag-bg" role="img" aria-label="Flag of Bulgaria"></span>
           <h2>Bulgaria</h2>
           <p>Border state on the EU’s external frontier with a focus on security and returns.</p>
           <span class="country-more">View profile →</span>
@@ -116,7 +116,7 @@
 
         <!-- Croatia -->
         <a href="countries/croatia.html" id="hr" class="country-card" data-region="southern" data-topic="labour-migration humanitarian-focus">
-          <img class="country-flag" src="assets/flags/hr.svg" alt="Flag of Croatia" width="28" height="20" />
+          <span class="country-flag flag-hr" role="img" aria-label="Flag of Croatia"></span>
           <h2>Croatia</h2>
           <p>Newer Schengen member strengthening reception while managing Balkan route flows.</p>
           <span class="country-more">View profile →</span>
@@ -124,7 +124,7 @@
 
         <!-- Cyprus -->
         <a href="countries/cyprus.html" id="cy" class="country-card" data-region="southern" data-topic="high-recognition humanitarian-focus">
-          <img class="country-flag" src="assets/flags/cy.svg" alt="Flag of Cyprus" width="28" height="20" />
+          <span class="country-flag flag-cy" role="img" aria-label="Flag of Cyprus"></span>
           <h2>Cyprus</h2>
           <p>Island state facing high asylum pressure relative to population size.</p>
           <span class="country-more">View profile →</span>
@@ -132,7 +132,7 @@
 
         <!-- Czechia -->
         <a href="countries/czechia.html" id="cz" class="country-card" data-region="eastern" data-topic="strict-policy">
-          <img class="country-flag" src="assets/flags/cz.svg" alt="Flag of Czechia" width="28" height="20" />
+          <span class="country-flag flag-cz" role="img" aria-label="Flag of Czechia"></span>
           <h2>Czechia</h2>
           <p>Central European state prioritising security vetting and temporary protection.</p>
           <span class="country-more">View profile →</span>
@@ -140,7 +140,7 @@
 
         <!-- Denmark -->
         <a href="countries/denmark.html" id="dk" class="country-card" data-region="northern" data-topic="strict-policy labour-migration">
-          <img class="country-flag" src="assets/flags/dk.svg" alt="Flag of Denmark" width="28" height="20" />
+          <span class="country-flag flag-dk" role="img" aria-label="Flag of Denmark"></span>
           <h2>Denmark</h2>
           <p>Opt-out EU member with restrictive asylum rules and labour migration schemes.</p>
           <span class="country-more">View profile →</span>
@@ -148,7 +148,7 @@
 
         <!-- Estonia -->
         <a href="countries/estonia.html" id="ee" class="country-card" data-region="northern" data-topic="high-recognition labour-migration">
-          <img class="country-flag" src="assets/flags/ee.svg" alt="Flag of Estonia" width="28" height="20" />
+          <span class="country-flag flag-ee" role="img" aria-label="Flag of Estonia"></span>
           <h2>Estonia</h2>
           <p>Digital-first administration managing migration with streamlined e-services.</p>
           <span class="country-more">View profile →</span>
@@ -156,7 +156,7 @@
 
         <!-- Finland -->
         <a href="countries/finland.html" id="fi" class="country-card" data-region="northern" data-topic="humanitarian-focus labour-migration">
-          <img class="country-flag" src="assets/flags/fi.svg" alt="Flag of Finland" width="28" height="20" />
+          <span class="country-flag flag-fi" role="img" aria-label="Flag of Finland"></span>
           <h2>Finland</h2>
           <p>Nordic system emphasising protection standards and orderly labour pathways.</p>
           <span class="country-more">View profile →</span>
@@ -164,7 +164,7 @@
 
         <!-- France -->
         <a href="countries/france.html" id="fr" class="country-card" data-region="western" data-topic="humanitarian-focus high-recognition">
-          <img class="country-flag" src="assets/flags/fr.svg" alt="Flag of France" width="28" height="20" />
+          <span class="country-flag flag-fr" role="img" aria-label="Flag of France"></span>
           <h2>France</h2>
           <p>Major destination balancing humanitarian reception with integration priorities.</p>
           <span class="country-more">View profile →</span>
@@ -172,7 +172,7 @@
 
         <!-- Germany -->
         <a href="countries/germany.html" id="de" class="country-card" data-region="western" data-topic="labour-migration high-recognition">
-          <img class="country-flag" src="assets/flags/de.svg" alt="Flag of Germany" width="28" height="20" />
+          <span class="country-flag flag-de" role="img" aria-label="Flag of Germany"></span>
           <h2>Germany</h2>
           <p>Largest EU recipient of protection seekers with reformed skilled migration laws.</p>
           <span class="country-more">View profile →</span>
@@ -180,7 +180,7 @@
 
         <!-- Greece -->
         <a href="countries/greece.html" id="gr" class="country-card" data-region="southern" data-topic="strict-policy">
-          <img class="country-flag" src="assets/flags/gr.svg" alt="Flag of Greece" width="28" height="20" />
+          <span class="country-flag flag-gr" role="img" aria-label="Flag of Greece"></span>
           <h2>Greece</h2>
           <p>Frontline state managing Aegean arrivals through EU-Türkiye cooperation.</p>
           <span class="country-more">View profile →</span>
@@ -188,7 +188,7 @@
 
         <!-- Hungary -->
         <a href="countries/hungary.html" id="hu" class="country-card" data-region="eastern" data-topic="strict-policy labour-migration">
-          <img class="country-flag" src="assets/flags/hu.svg" alt="Flag of Hungary" width="28" height="20" />
+          <span class="country-flag flag-hu" role="img" aria-label="Flag of Hungary"></span>
           <h2>Hungary</h2>
           <p>Implements fence-based border controls and limited asylum access points.</p>
           <span class="country-more">View profile →</span>
@@ -196,7 +196,7 @@
 
         <!-- Ireland -->
         <a href="countries/ireland.html" id="ie" class="country-card" data-region="western" data-topic="humanitarian-focus">
-          <img class="country-flag" src="assets/flags/ie.svg" alt="Flag of Ireland" width="28" height="20" />
+          <span class="country-flag flag-ie" role="img" aria-label="Flag of Ireland"></span>
           <h2>Ireland</h2>
           <p>Common Travel Area member overhauling reception and direct provision systems.</p>
           <span class="country-more">View profile →</span>
@@ -204,7 +204,7 @@
 
         <!-- Italy -->
         <a href="countries/italy.html" id="it" class="country-card" data-region="southern" data-topic="strict-policy humanitarian-focus labour-migration">
-          <img class="country-flag" src="assets/flags/it.svg" alt="Flag of Italy" width="28" height="20" />
+          <span class="country-flag flag-it" role="img" aria-label="Flag of Italy"></span>
           <h2>Italy</h2>
           <p>
             Key entry point on the Central Mediterranean route with
@@ -215,7 +215,7 @@
 
         <!-- Latvia -->
         <a href="countries/latvia.html" id="lv" class="country-card" data-region="northern" data-topic="strict-policy">
-          <img class="country-flag" src="assets/flags/lv.svg" alt="Flag of Latvia" width="28" height="20" />
+          <span class="country-flag flag-lv" role="img" aria-label="Flag of Latvia"></span>
           <h2>Latvia</h2>
           <p>Border state emphasising security screenings and rapid response capacity.</p>
           <span class="country-more">View profile →</span>
@@ -223,7 +223,7 @@
 
         <!-- Lithuania -->
         <a href="countries/lithuania.html" id="lt" class="country-card" data-region="eastern" data-topic="strict-policy labour-migration">
-          <img class="country-flag" src="assets/flags/lt.svg" alt="Flag of Lithuania" width="28" height="20" />
+          <span class="country-flag flag-lt" role="img" aria-label="Flag of Lithuania"></span>
           <h2>Lithuania</h2>
           <p>Developing asylum infrastructure after recent hybrid border pressures.</p>
           <span class="country-more">View profile →</span>
@@ -231,7 +231,7 @@
 
         <!-- Luxembourg -->
         <a href="countries/luxembourg.html" id="lu" class="country-card" data-region="western" data-topic="high-recognition humanitarian-focus">
-          <img class="country-flag" src="assets/flags/lu.svg" alt="Flag of Luxembourg" width="28" height="20" />
+          <span class="country-flag flag-lu" role="img" aria-label="Flag of Luxembourg"></span>
           <h2>Luxembourg</h2>
           <p>Small state with coordinated reception services and multilingual integration.</p>
           <span class="country-more">View profile →</span>
@@ -239,7 +239,7 @@
 
         <!-- Malta -->
         <a href="countries/malta.html" id="mt" class="country-card" data-region="southern" data-topic="high-recognition humanitarian-focus">
-          <img class="country-flag" src="assets/flags/mt.svg" alt="Flag of Malta" width="28" height="20" />
+          <span class="country-flag flag-mt" role="img" aria-label="Flag of Malta"></span>
           <h2>Malta</h2>
           <p>Mediterranean island managing boat arrivals with EU burden-sharing calls.</p>
           <span class="country-more">View profile →</span>
@@ -247,7 +247,7 @@
 
         <!-- Netherlands -->
         <a href="countries/netherlands.html" id="nl" class="country-card" data-region="western" data-topic="labour-migration high-recognition">
-          <img class="country-flag" src="assets/flags/nl.svg" alt="Flag of the Netherlands" width="28" height="20" />
+          <span class="country-flag flag-nl" role="img" aria-label="Flag of the Netherlands"></span>
           <h2>Netherlands</h2>
           <p>Focuses on skilled migration, civic integration, and decentralised reception.</p>
           <span class="country-more">View profile →</span>
@@ -255,7 +255,7 @@
 
         <!-- Poland -->
         <a href="countries/poland.html" id="pl" class="country-card" data-region="eastern" data-topic="strict-policy">
-          <img class="country-flag" src="assets/flags/pl.svg" alt="Flag of Poland" width="28" height="20" />
+          <span class="country-flag flag-pl" role="img" aria-label="Flag of Poland"></span>
           <h2>Poland</h2>
           <p>Hosts millions under temporary protection while reinforcing eastern borders.</p>
           <span class="country-more">View profile →</span>
@@ -263,7 +263,7 @@
 
         <!-- Portugal -->
         <a href="countries/portugal.html" id="pt" class="country-card" data-region="southern" data-topic="high-recognition labour-migration humanitarian-focus">
-          <img class="country-flag" src="assets/flags/pt.svg" alt="Flag of Portugal" width="28" height="20" />
+          <span class="country-flag flag-pt" role="img" aria-label="Flag of Portugal"></span>
           <h2>Portugal</h2>
           <p>Proactive recruitment of workers paired with inclusive integration policies.</p>
           <span class="country-more">View profile →</span>
@@ -271,7 +271,7 @@
 
         <!-- Romania -->
         <a href="countries/romania.html" id="ro" class="country-card" data-region="eastern" data-topic="humanitarian-focus labour-migration">
-          <img class="country-flag" src="assets/flags/ro.svg" alt="Flag of Romania" width="28" height="20" />
+          <span class="country-flag flag-ro" role="img" aria-label="Flag of Romania"></span>
           <h2>Romania</h2>
           <p>Key hub for Ukrainian displacement response and managed labour inflows.</p>
           <span class="country-more">View profile →</span>
@@ -279,7 +279,7 @@
 
         <!-- Slovakia -->
         <a href="countries/slovakia.html" id="sk" class="country-card" data-region="eastern" data-topic="strict-policy">
-          <img class="country-flag" src="assets/flags/sk.svg" alt="Flag of Slovakia" width="28" height="20" />
+          <span class="country-flag flag-sk" role="img" aria-label="Flag of Slovakia"></span>
           <h2>Slovakia</h2>
           <p>Border management emphasises security cooperation and temporary protection.</p>
           <span class="country-more">View profile →</span>
@@ -287,7 +287,7 @@
 
         <!-- Slovenia -->
         <a href="countries/slovenia.html" id="si" class="country-card" data-region="southern" data-topic="humanitarian-focus">
-          <img class="country-flag" src="assets/flags/si.svg" alt="Flag of Slovenia" width="28" height="20" />
+          <span class="country-flag flag-si" role="img" aria-label="Flag of Slovenia"></span>
           <h2>Slovenia</h2>
           <p>Bridges Balkan and Alpine routes with solidarity-based relocation pledges.</p>
           <span class="country-more">View profile →</span>
@@ -295,7 +295,7 @@
 
         <!-- Spain -->
         <a href="countries/spain.html" id="es" class="country-card" data-region="southern" data-topic="high-recognition humanitarian-focus labour-migration">
-          <img class="country-flag" src="assets/flags/es.svg" alt="Flag of Spain" width="28" height="20" />
+          <span class="country-flag flag-es" role="img" aria-label="Flag of Spain"></span>
           <h2>Spain</h2>
           <p>
             Spain has been a member of the European Union since January 1, 1986.
@@ -305,7 +305,7 @@
 
         <!-- Sweden -->
         <a href="countries/sweden.html" id="se" class="country-card" data-region="northern" data-topic="high-recognition humanitarian-focus">
-          <img class="country-flag" src="assets/flags/se.svg" alt="Flag of Sweden" width="28" height="20" />
+          <span class="country-flag flag-se" role="img" aria-label="Flag of Sweden"></span>
           <h2>Sweden</h2>
           <p>Long-standing refugee destination now tightening rules while supporting integration.</p>
           <span class="country-more">View profile →</span>

--- a/countries/austria.html
+++ b/countries/austria.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/at.svg"
-               alt="Flag of Austria"
-               width="28" height="20" />
+          <span class="country-flag flag-at" role="img" aria-label="Flag of Austria"></span>
           <h1>Austria</h1>
         </div>
         <p>

--- a/countries/belgium.html
+++ b/countries/belgium.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/be.svg"
-               alt="Flag of Belgium"
-               width="28" height="20" />
+          <span class="country-flag flag-be" role="img" aria-label="Flag of Belgium"></span>
           <h1>Belgium</h1>
         </div>
         <p>

--- a/countries/bulgaria.html
+++ b/countries/bulgaria.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/bg.svg"
-               alt="Flag of Bulgaria"
-               width="28" height="20" />
+          <span class="country-flag flag-bg" role="img" aria-label="Flag of Bulgaria"></span>
           <h1>Bulgaria</h1>
         </div>
         <p>

--- a/countries/croatia.html
+++ b/countries/croatia.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/hr.svg"
-               alt="Flag of Croatia"
-               width="28" height="20" />
+          <span class="country-flag flag-hr" role="img" aria-label="Flag of Croatia"></span>
           <h1>Croatia</h1>
         </div>
         <p>

--- a/countries/cyprus.html
+++ b/countries/cyprus.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/cy.svg"
-               alt="Flag of Cyprus"
-               width="28" height="20" />
+          <span class="country-flag flag-cy" role="img" aria-label="Flag of Cyprus"></span>
           <h1>Cyprus</h1>
         </div>
         <p>

--- a/countries/czechia.html
+++ b/countries/czechia.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/cz.svg"
-               alt="Flag of Czechia"
-               width="28" height="20" />
+          <span class="country-flag flag-cz" role="img" aria-label="Flag of Czechia"></span>
           <h1>Czechia</h1>
         </div>
         <p>

--- a/countries/denmark.html
+++ b/countries/denmark.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/dk.svg"
-               alt="Flag of Denmark"
-               width="28" height="20" />
+          <span class="country-flag flag-dk" role="img" aria-label="Flag of Denmark"></span>
           <h1>Denmark</h1>
         </div>
         <p>

--- a/countries/estonia.html
+++ b/countries/estonia.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/ee.svg"
-               alt="Flag of Estonia"
-               width="28" height="20" />
+          <span class="country-flag flag-ee" role="img" aria-label="Flag of Estonia"></span>
           <h1>Estonia</h1>
         </div>
         <p>

--- a/countries/finland.html
+++ b/countries/finland.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/fi.svg"
-               alt="Flag of Finland"
-               width="28" height="20" />
+          <span class="country-flag flag-fi" role="img" aria-label="Flag of Finland"></span>
           <h1>Finland</h1>
         </div>
         <p>

--- a/countries/france.html
+++ b/countries/france.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/fr.svg"
-               alt="Flag of France"
-               width="28" height="20" />
+          <span class="country-flag flag-fr" role="img" aria-label="Flag of France"></span>
           <h1>France</h1>
         </div>
         <p>

--- a/countries/germany.html
+++ b/countries/germany.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/de.svg"
-               alt="Flag of Germany"
-               width="28" height="20" />
+          <span class="country-flag flag-de" role="img" aria-label="Flag of Germany"></span>
           <h1>Germany</h1>
         </div>
         <p>

--- a/countries/greece.html
+++ b/countries/greece.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/gr.svg"
-               alt="Flag of Greece"
-               width="28" height="20" />
+          <span class="country-flag flag-gr" role="img" aria-label="Flag of Greece"></span>
           <h1>Greece</h1>
         </div>
         <p>

--- a/countries/hungary.html
+++ b/countries/hungary.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/hu.svg"
-               alt="Flag of Hungary"
-               width="28" height="20" />
+          <span class="country-flag flag-hu" role="img" aria-label="Flag of Hungary"></span>
           <h1>Hungary</h1>
         </div>
         <p>

--- a/countries/ireland.html
+++ b/countries/ireland.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/ie.svg"
-               alt="Flag of Ireland"
-               width="28" height="20" />
+          <span class="country-flag flag-ie" role="img" aria-label="Flag of Ireland"></span>
           <h1>Ireland</h1>
         </div>
         <p>

--- a/countries/italy.html
+++ b/countries/italy.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/it.svg"
-               alt="Flag of Italy"
-               width="28" height="20" />
+          <span class="country-flag flag-it" role="img" aria-label="Flag of Italy"></span>
           <h1>Italy</h1>
         </div>
         <p>

--- a/countries/latvia.html
+++ b/countries/latvia.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/lv.svg"
-               alt="Flag of Latvia"
-               width="28" height="20" />
+          <span class="country-flag flag-lv" role="img" aria-label="Flag of Latvia"></span>
           <h1>Latvia</h1>
         </div>
         <p>

--- a/countries/lithuania.html
+++ b/countries/lithuania.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/lt.svg"
-               alt="Flag of Lithuania"
-               width="28" height="20" />
+          <span class="country-flag flag-lt" role="img" aria-label="Flag of Lithuania"></span>
           <h1>Lithuania</h1>
         </div>
         <p>

--- a/countries/luxembourg.html
+++ b/countries/luxembourg.html
@@ -31,10 +31,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/lu.svg"
-               alt="Flag of Luxembourg"
-               width="28" height="20" />
+          <span class="country-flag flag-lu" role="img" aria-label="Flag of Luxembourg"></span>
           <h1>Luxembourg</h1>
         </div>
         <p>

--- a/countries/malta.html
+++ b/countries/malta.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/mt.svg"
-               alt="Flag of Malta"
-               width="28" height="20" />
+          <span class="country-flag flag-mt" role="img" aria-label="Flag of Malta"></span>
           <h1>Malta</h1>
         </div>
         <p>

--- a/countries/netherlands.html
+++ b/countries/netherlands.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/nl.svg"
-               alt="Flag of the Netherlands"
-               width="28" height="20" />
+          <span class="country-flag flag-nl" role="img" aria-label="Flag of the Netherlands"></span>
           <h1>Netherlands</h1>
         </div>
         <p>

--- a/countries/poland.html
+++ b/countries/poland.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/pl.svg"
-               alt="Flag of Poland"
-               width="28" height="20" />
+          <span class="country-flag flag-pl" role="img" aria-label="Flag of Poland"></span>
           <h1>Poland</h1>
         </div>
         <p>

--- a/countries/portugal.html
+++ b/countries/portugal.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/pt.svg"
-               alt="Flag of Portugal"
-               width="28" height="20" />
+          <span class="country-flag flag-pt" role="img" aria-label="Flag of Portugal"></span>
           <h1>Portugal</h1>
         </div>
         <p>

--- a/countries/romania.html
+++ b/countries/romania.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/ro.svg"
-               alt="Flag of Romania"
-               width="28" height="20" />
+          <span class="country-flag flag-ro" role="img" aria-label="Flag of Romania"></span>
           <h1>Romania</h1>
         </div>
         <p>

--- a/countries/slovakia.html
+++ b/countries/slovakia.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/sk.svg"
-               alt="Flag of Slovakia"
-               width="28" height="20" />
+          <span class="country-flag flag-sk" role="img" aria-label="Flag of Slovakia"></span>
           <h1>Slovakia</h1>
         </div>
         <p>

--- a/countries/slovenia.html
+++ b/countries/slovenia.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/si.svg"
-               alt="Flag of Slovenia"
-               width="28" height="20" />
+          <span class="country-flag flag-si" role="img" aria-label="Flag of Slovenia"></span>
           <h1>Slovenia</h1>
         </div>
         <p>

--- a/countries/spain.html
+++ b/countries/spain.html
@@ -30,10 +30,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/es.svg"
-               alt="Flag of Spain"
-               width="28" height="20" />
+          <span class="country-flag flag-es" role="img" aria-label="Flag of Spain"></span>
           <h1>Spain</h1>
         </div>
         <p>

--- a/countries/sweden.html
+++ b/countries/sweden.html
@@ -29,10 +29,7 @@
     <main class="page-main">
       <section class="page-intro">
         <div class="country-title">
-          <img class="country-flag"
-               src="../assets/flags/se.svg"
-               alt="Flag of Sweden"
-               width="28" height="20" />
+          <span class="country-flag flag-se" role="img" aria-label="Flag of Sweden"></span>
           <h1>Sweden</h1>
         </div>
         <p>


### PR DESCRIPTION
## Summary
- replace flag img tags with ISO2-based flag utility classes across country listings and profile pages
- add centralized flag background styles and per-country mappings pointing to shared SVG assets

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941cf5b73808320945f681565c42088)