### PR TITLE
Improve map stroke visibility across themes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -69,9 +69,11 @@
   /* Animation */
   --transition-fast: 0.15s ease-out;
 
-  /* Map strokes (centralized) */
-  --map-stroke-eu: rgba(17, 24, 39, 0.85);
-  --map-stroke-non-eu: rgba(15, 23, 42, 0.35);
+  /* Map styling */
+  --map-stroke: rgba(20, 30, 45, 0.25);
+  --map-stroke-width: 1;
+  --map-eu-fill: rgba(120, 130, 150, 0.22);
+  --map-non-eu-fill: rgba(70, 80, 100, 0.16);
 }
 
 body.theme-dark {
@@ -95,9 +97,11 @@ body.theme-dark {
   --shadow-soft: 0 10px 28px rgba(0, 0, 0, 0.35);
   --shadow-soft-light: 0 10px 28px rgba(0, 0, 0, 0.35);
 
-  /* Map strokes in dark mode */
-  --map-stroke-eu: rgba(226, 232, 240, 0.8);
-  --map-stroke-non-eu: rgba(255, 255, 255, 0.78);
+  /* Map styling in dark mode */
+  --map-stroke: rgba(255, 255, 255, 0.35);
+  --map-stroke-width: 1.1;
+  --map-eu-fill: rgba(140, 150, 170, 0.28);
+  --map-non-eu-fill: rgba(220, 230, 245, 0.55);
 
   color-scheme: dark;
 }
@@ -464,24 +468,19 @@ body.theme-dark .page-country .interactive-map {
 
 .interactive-map svg path[id] {
   fill: none;
-  stroke: rgba(255, 255, 255, 0.35);
-  stroke-width: 1;
+  stroke: var(--map-stroke);
+  stroke-width: var(--map-stroke-width);
   vector-effect: non-scaling-stroke;
+  stroke-linejoin: round;
   transition: fill var(--transition-fast), stroke var(--transition-fast), stroke-width var(--transition-fast);
 }
 
 .interactive-map svg path.eu-member {
-  fill: #c3c9da;
-  stroke: rgba(255, 255, 255, 0.45);
-}
-
-body.theme-dark .page-country .interactive-map svg path.eu-member {
-  fill: rgba(82, 104, 140, 0.65);
+  fill: var(--map-eu-fill);
 }
 
 .interactive-map svg path.non-eu {
-  fill: transparent;
-  stroke: rgba(255, 255, 255, 0.25);
+  fill: var(--map-non-eu-fill);
 }
 
 .interactive-map svg path.is-clickable {
@@ -1459,10 +1458,10 @@ body.theme-light.index .hero-visual .interactive-map {
 
 /* Homepage-specific stroke tweak via vars (no !important chaos) */
 body.theme-dark.index {
-  --map-stroke-non-eu: rgba(255, 255, 255, 0.8);
+  --map-stroke: rgba(255, 255, 255, 0.8);
 }
 body.theme-light.index {
-  --map-stroke-non-eu: rgba(30, 41, 59, 0.6);
+  --map-stroke: rgba(30, 41, 59, 0.6);
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary
- add theme-based variables for map strokes and fills so map borders stay visible across themes
- apply consistent stroke styling to all map paths and use shared fill variables for EU and non-EU countries
- align homepage stroke overrides with the new map stroke variable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941da39d7688320a3655bff1ddcab7d)