### PR TITLE
Improve map styling for EU and non-EU countries

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -70,10 +70,12 @@
   --transition-fast: 0.15s ease-out;
 
   /* Map styling */
-  --map-stroke: rgba(20, 30, 45, 0.25);
-  --map-stroke-width: 1;
-  --map-eu-fill: rgba(120, 130, 150, 0.22);
-  --map-non-eu-fill: rgba(70, 80, 100, 0.16);
+  --map-border: rgba(0, 0, 0, 0.3);
+  --map-non-eu-border: rgba(0, 0, 0, 0.22);
+  --map-eu-fill: rgba(170, 185, 210, 0.85);
+  --map-selected-fill: #1f6feb;
+  --map-selected-border: rgba(0, 0, 0, 0.35);
+  --map-stroke-width: 1.2;
 }
 
 body.theme-dark {
@@ -98,10 +100,11 @@ body.theme-dark {
   --shadow-soft-light: 0 10px 28px rgba(0, 0, 0, 0.35);
 
   /* Map styling in dark mode */
-  --map-stroke: rgba(255, 255, 255, 0.35);
-  --map-stroke-width: 1.1;
-  --map-eu-fill: rgba(140, 150, 170, 0.28);
-  --map-non-eu-fill: rgba(220, 230, 245, 0.55);
+  --map-border: rgba(255, 255, 255, 0.35);
+  --map-non-eu-border: rgba(255, 255, 255, 0.25);
+  --map-eu-fill: rgba(220, 230, 245, 0.85);
+  --map-selected-fill: #1f6feb;
+  --map-selected-border: rgba(255, 255, 255, 0.55);
 
   color-scheme: dark;
 }
@@ -466,35 +469,40 @@ body.theme-dark .page-country .interactive-map {
   height: auto;
 }
 
-.interactive-map svg path[id] {
-  fill: none;
-  stroke: var(--map-stroke);
+.interactive-map svg .country {
+  fill: transparent;
+  stroke: var(--map-border);
   stroke-width: var(--map-stroke-width);
   vector-effect: non-scaling-stroke;
   stroke-linejoin: round;
   transition: fill var(--transition-fast), stroke var(--transition-fast), stroke-width var(--transition-fast);
 }
 
-.interactive-map svg path.eu-member {
+.interactive-map svg .country.eu {
   fill: var(--map-eu-fill);
 }
 
-.interactive-map svg path.non-eu {
-  fill: var(--map-non-eu-fill);
+.interactive-map svg .country.non-eu {
+  fill: transparent;
+  stroke: var(--map-non-eu-border);
 }
 
-.interactive-map svg path.is-clickable {
+.interactive-map svg .country.is-clickable {
   cursor: pointer;
 }
 
-.interactive-map svg path.is-hovered {
+.interactive-map svg .country.is-hovered {
   fill: var(--eu-gold);
-  stroke: #0f172a;
-  stroke-width: 0.8;
+  stroke: var(--map-selected-border);
+  stroke-width: calc(var(--map-stroke-width) * 0.9);
 }
 
-.interactive-map svg path.is-highlighted {
-  stroke-width: 2;
+.interactive-map svg .country.is-highlighted,
+.interactive-map svg .country.selected,
+.interactive-map svg .country.active {
+  fill: var(--map-selected-fill);
+  stroke: var(--map-selected-border);
+  stroke-width: var(--map-stroke-width);
 }
 
 .interactive-map .map-tooltip {
@@ -553,10 +561,8 @@ body.theme-dark .page-country .interactive-map {
 }
 
 /* Active country highlight for any page */
-.interactive-map svg path.is-highlighted {
-  fill: #2563eb;
-  stroke: #1e293b;
-  stroke-width: 1.2;
+.interactive-map svg .country.is-highlighted {
+  stroke-width: calc(var(--map-stroke-width) + 0.15);
 }
 
 @media (max-width: 900px) {
@@ -1458,10 +1464,10 @@ body.theme-light.index .hero-visual .interactive-map {
 
 /* Homepage-specific stroke tweak via vars (no !important chaos) */
 body.theme-dark.index {
-  --map-stroke: rgba(255, 255, 255, 0.8);
+  --map-border: rgba(255, 255, 255, 0.8);
 }
 body.theme-light.index {
-  --map-stroke: rgba(30, 41, 59, 0.6);
+  --map-border: rgba(30, 41, 59, 0.6);
 }
 
 /* ========================================

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -266,7 +266,7 @@ document.addEventListener('DOMContentLoaded', () => {
           if (activeCode) {
             const targetPath = svg.querySelector(`#${activeCode.toUpperCase()}`);
             if (targetPath) {
-              targetPath.classList.add('is-highlighted');
+              targetPath.classList.add('country', 'is-highlighted', 'selected');
               targetPath.setAttribute('aria-current', 'true');
             }
           }
@@ -306,7 +306,7 @@ document.addEventListener('DOMContentLoaded', () => {
               countryProfiles[countryCode] ||
               (isEuMember ? overviewHref : null);
 
-            path.classList.add(isEuMember ? 'eu-member' : 'non-eu');
+            path.classList.add('country', isEuMember ? 'eu' : 'non-eu');
 
             path.addEventListener('mouseenter', () => {
               tooltip.textContent = countryName;


### PR DESCRIPTION
## Summary
- adjust map color variables to keep EU fills and non-EU borders distinct across themes
- update map styling classes to preserve strokes without using opacity and highlight selected countries consistently
- tag SVG paths with unified country classes in JavaScript to match the new styling rules

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941dc412ee08320947a0a65fb325133)