### PR TITLE
Adjust map stroke width

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -75,7 +75,7 @@
   --map-eu-fill: rgba(170, 185, 210, 0.85);
   --map-selected-fill: #1f6feb;
   --map-selected-border: rgba(0, 0, 0, 0.35);
-  --map-stroke-width: 1.2;
+  --map-stroke-width: 0.8;
 }
 
 body.theme-dark {


### PR DESCRIPTION
## Summary
- reduce the global map stroke width variable to 0.8 to lighten country borders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941dedfe4e08320a36477ecee7a5f7a)