### PR TITLE
Remove bottom padding below main content

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -250,7 +250,7 @@ body.compare-page {
 }
 
 .site-main {
-  padding: 0 0 3rem;
+  padding: 0;
 }
 
 .page-main {


### PR DESCRIPTION
## Summary
- remove extra padding at the bottom of the main content wrapper so the footer aligns directly beneath page sections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694280936918832087a9f46c804faa7a)