### PR TITLE
Revamp Austria hero and policy snapshot layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -700,107 +700,162 @@ body.theme-light .country-section-card {
 }
 
 .country-hero {
-  background: var(--bg-light);
-  border: 1px solid var(--border-soft-light);
-  border-radius: var(--radius-lg);
-  padding: 2.2rem 2.4rem;
-  box-shadow: var(--shadow-soft-light);
+  background: linear-gradient(180deg, rgba(12, 28, 52, 0.85) 0%, rgba(12, 28, 52, 0.7) 60%, rgba(12, 28, 52, 0) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem 1.1rem;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25) inset;
+  margin-bottom: 18px;
+  color: #f4f7fb;
 }
 
-body.theme-dark .country-hero {
-  background: var(--bg-surface-elevated);
-  border-color: var(--border-soft);
-  box-shadow: var(--shadow-soft);
+.country-hero h1 {
+  margin: 0 0.25rem 0 0;
 }
 
-.country-hero__tagline {
-  margin: 0.35rem 0 0;
-  font-size: 1.05rem;
-  color: var(--text-muted-light);
+.country-hero .subtitle {
+  color: rgba(255, 255, 255, 0.8);
+  margin-top: 0.6rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.grid-hero {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 900px) {
+  .grid-hero {
+    grid-template-columns: 1fr 320px;
+    align-items: start;
+  }
+}
+
+.hero-left h1 {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.hero-map-card {
+  background: rgba(10, 22, 40, 0.38);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  padding: 0.6rem;
+}
+
+.hero-map-card .interactive-map {
+  min-height: 240px;
+  background: transparent;
+  box-shadow: none;
+  border-radius: 12px;
+}
+
+.hero-map-card .interactive-map svg path.eu {
+  fill: #dbe6f2;
+}
+
+.hero-map-card .interactive-map svg path.non-eu {
+  fill: transparent;
+}
+
+.hero-map-card .interactive-map svg path.is-highlighted {
+  fill: var(--atlas-blue, #2f6ff1);
+}
+
+.hero-map-card .interactive-map svg path {
+  stroke: rgba(255, 255, 255, 0.32);
+  stroke-width: 0.9;
 }
 
 .policy-snapshot {
+  margin-top: 14px;
+  padding: 22px 20px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
   background: radial-gradient(
       120% 140% at 20% 0%,
-      rgba(35, 80, 140, 0.22) 0%,
+      rgba(35, 80, 140, 0.18) 0%,
       rgba(8, 20, 35, 0.78) 55%,
       rgba(5, 12, 22, 0.86) 100%
     );
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: var(--radius-lg);
-  padding: 3rem 2.3rem 2.2rem;
-  box-shadow: var(--shadow-soft);
-  color: #f3f7ff;
 }
 
-body.theme-dark .policy-snapshot {
-  background: radial-gradient(
-      120% 140% at 20% 0%,
-      rgba(35, 80, 140, 0.2) 0%,
-      rgba(6, 16, 28, 0.85) 55%,
-      rgba(4, 10, 20, 0.9) 100%
-    );
-  border-color: rgba(255, 255, 255, 0.12);
+.policy-snapshot .eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 0.7rem;
 }
 
-.policy-snapshot .section-header {
-  margin-bottom: 1.5rem;
+.policy-snapshot .section-title {
+  color: var(--atlas-gold, #f0c44e);
+  margin: 0 0 0.4rem 0;
 }
 
-.policy-snapshot .section-eyebrow {
-  margin-bottom: 0.85rem;
-}
-
-.policy-snapshot .section-header h2 {
-  margin-top: 0;
-  color: #f9fbff;
-}
-
-.policy-snapshot .section-lead {
-  margin-bottom: 0;
-  color: rgba(243, 247, 255, 0.88);
+.policy-snapshot .section-subtitle {
+  color: rgba(255, 255, 255, 0.78);
+  margin: 0 0 1.1rem 0;
 }
 
 .snapshot-grid {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  margin: 0;
-  padding: 0;
+  gap: 0.9rem;
+  grid-template-columns: 1fr;
 }
 
-.snapshot-item {
-  padding: 1.25rem 1.25rem;
-  border-radius: 14px;
+@media (min-width: 840px) {
+  .snapshot-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.snapshot-card {
+  background: rgba(12, 28, 52, 0.28);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(10, 25, 45, 0.35);
-  box-shadow: var(--shadow-soft);
-  backdrop-filter: blur(6px);
+  border-radius: 14px;
+  padding: 1.1rem 1rem;
 }
 
 .snapshot-label {
-  margin: 0 0 0.6rem;
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--atlas-gold, #f0c44e);
+  margin-bottom: 0.55rem;
 }
 
 .snapshot-value {
-  margin: 0;
   color: rgba(255, 255, 255, 0.92);
-  font-weight: 700;
+  font-weight: 600;
   line-height: 1.45;
-  font-size: 1.05rem;
+  font-size: 1.02rem;
 }
 
 .snapshot-value.is-pill {
   display: inline-block;
-  padding: 0.35rem 0.6rem;
+  padding: 0.32rem 0.7rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+:root[data-theme="light"] .snapshot-card {
+  background: rgba(255, 255, 255, 0.7);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+:root[data-theme="light"] .policy-snapshot {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(240, 245, 252, 0.9) 100%);
+  border-color: rgba(0, 0, 0, 0.06);
+}
+
+:root[data-theme="light"] .snapshot-label {
+  color: #9a7722;
 }
 
 .country-accordion .accordion {

--- a/countries/austria.html
+++ b/countries/austria.html
@@ -28,38 +28,42 @@
 
   <main class="page-main country-profile">
     <section class="country-hero section">
-      <div class="country-hero__heading">
-        <div class="country-title">
-          <span class="country-flag flag-at" role="img" aria-label="Flag of Austria"></span>
-          <h1>Austria</h1>
+      <div class="grid-hero">
+        <div class="hero-left">
+          <h1><span class="country-flag flag-at" role="img" aria-label="Flag of Austria"></span> Austria</h1>
+          <p class="subtitle">Schengen member balancing humanitarian obligations with firm border control.</p>
         </div>
-        <p class="country-hero__tagline">Schengen member balancing humanitarian obligations with firm border control.</p>
+
+        <aside class="hero-map-card" aria-label="Austria in Europe">
+          <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="at"></div>
+        </aside>
       </div>
     </section>
 
     <section class="section policy-snapshot">
-      <div class="section-header">
-        <p class="section-eyebrow">POLICY PROFILE</p>
-        <h2>At a glance</h2>
-        <p class="section-lead">Concise view of Austria&rsquo;s position in the EU migration landscape.</p>
-      </div>
+      <div class="eyebrow">Policy profile</div>
+      <h2 class="section-title">Policy essentials</h2>
+      <p class="section-subtitle">Concise view of Austria&rsquo;s position in the EU migration landscape.</p>
 
       <div class="snapshot-grid">
-        <div class="snapshot-item">
-          <p class="snapshot-label">Position in EU migration system</p>
-          <p class="snapshot-value">Central transit and destination state within Schengen.</p>
+        <div class="snapshot-card">
+          <div class="snapshot-label">Position in EU migration system</div>
+          <div class="snapshot-value">Central transit and destination state within Schengen.</div>
         </div>
-        <div class="snapshot-item">
-          <p class="snapshot-label">Primary policy focus</p>
-          <p class="snapshot-value">Deterrence, border control, and limitation of secondary movements.</p>
+
+        <div class="snapshot-card">
+          <div class="snapshot-label">Primary policy focus</div>
+          <div class="snapshot-value">Deterrence, border control, and limitation of secondary movements.</div>
         </div>
-        <div class="snapshot-item">
-          <p class="snapshot-label">Pressure level</p>
-          <p class="snapshot-value is-pill">Medium–High</p>
+
+        <div class="snapshot-card">
+          <div class="snapshot-label">Pressure level</div>
+          <div class="snapshot-value is-pill">Medium–High</div>
         </div>
-        <div class="snapshot-item">
-          <p class="snapshot-label">Key tension</p>
-          <p class="snapshot-value">EU solidarity mechanisms vs. national capacity and political resistance.</p>
+
+        <div class="snapshot-card">
+          <div class="snapshot-label">Key tension</div>
+          <div class="snapshot-value">EU solidarity mechanisms vs. national capacity and political resistance.</div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- restyle the Austria hero with a compact gradient card and embedded map context
- update the policy snapshot block with new headings and lighter snapshot cards
- tune light-mode gradients and label colors for the refreshed cards

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942928c4c0483209eae46d2baa5b3c9)