### PR TITLE
Improve policy eyebrow spacing

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -832,6 +832,7 @@ body.theme-light .country-section-card {
 .policy-snapshot {
   margin-top: 14px;
   padding: 30px 20px 18px;
+  padding-top: 32px !important;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 18px;
   background: radial-gradient(
@@ -848,6 +849,14 @@ body.theme-light .country-section-card {
   color: rgba(255, 255, 255, 0.6);
   margin-top: 6px;
   margin-bottom: 14px;
+}
+
+.policy-snapshot .eyebrow,
+.policy-profile .eyebrow,
+.policy-section .eyebrow {
+  display: block;
+  margin-top: 24px !important;
+  padding-top: 8px !important;
 }
 
 .policy-snapshot .section-title {


### PR DESCRIPTION
## Summary
- force consistent top spacing directly on policy eyebrow labels
- add backup top padding to the policy snapshot container to keep the header offset

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694298e6bde08320aa6e24fd0677603d)