### PR TITLE
Adjust Austria mini map styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,15 @@ These rules apply to all AI-assisted changes in this repository.
 - No whitespace-only changes.
 - Use existing CSS variables and the current theme system.
 
+## Map styling constraints
+- All EU map borders must use stroke-width: 0.8 (via CSS variable preferred).
+- EU hover behavior is mandatory: EU regions must turn yellow on hover.
+- Mini-maps on country pages must be interactive (inline/embedded SVG that supports hover/click).
+- Every map container must have a constant ombre/glow:
+  - Light mode: blue
+  - Dark mode: white
+- No frames/borders around map containers.
+
 ## Map rendering constraints
 - SVG country borders must use a stroke-width of 0.8.
 - Border thickness may not be altered without explicit instruction.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -811,8 +811,8 @@ body.theme-light .country-section-card {
 
 .hero-map-card .interactive-map {
   min-height: 240px;
-  background: transparent;
-  box-shadow: none;
+  background: var(--map-ombre-light);
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.12);
   border-radius: 12px;
 }
 
@@ -831,6 +831,7 @@ body.theme-light .country-section-card {
 .hero-map-card .interactive-map svg path {
   stroke: var(--map-non-eu-border);
   stroke-width: var(--map-stroke-width);
+  vector-effect: non-scaling-stroke;
 }
 
 body.theme-dark .hero-map-card {
@@ -843,6 +844,11 @@ body.theme-dark .hero-map-card .interactive-map svg path.eu {
 
 body.theme-dark .hero-map-card .interactive-map svg path.non-eu {
   stroke: var(--map-non-eu-border);
+}
+
+body.theme-dark .hero-map-card .interactive-map {
+  background: var(--map-ombre-dark);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.32);
 }
 
 :root[data-theme="light"] .hero-map-card {


### PR DESCRIPTION
## Summary
- add repository map styling constraints to AGENTS guidance
- apply ombre glow and consistent stroke handling to the Austria hero mini-map container

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942ae3611a883209234b39f5c5a1f8b)