### PR TITLE
Align Austria map styling with homepage

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -809,11 +809,25 @@ body.theme-light .country-section-card {
   box-shadow: none;
 }
 
+.page-country .hero-map-card.hero-visual {
+  background: transparent;
+  border: none;
+  padding: 0;
+  box-shadow: none;
+  min-height: auto;
+}
+
 .hero-map-card .interactive-map {
   min-height: 240px;
   background: var(--map-ombre-light);
   box-shadow: 0 14px 34px rgba(15, 23, 42, 0.12);
   border-radius: 12px;
+}
+
+.page-country .hero-map-card.hero-visual .interactive-map {
+  min-height: 240px;
+  background: var(--map-ombre-light);
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.12);
 }
 
 .hero-map-card .interactive-map svg path.eu {
@@ -822,6 +836,13 @@ body.theme-light .country-section-card {
 
 .hero-map-card .interactive-map svg path.non-eu {
   fill: transparent;
+}
+
+.hero-map-card .interactive-map svg .country.eu.is-hovered,
+.hero-map-card .interactive-map svg .country.eu:hover {
+  fill: var(--eu-gold) !important;
+  stroke: var(--map-eu-border);
+  stroke-width: var(--map-stroke-width);
 }
 
 .hero-map-card .interactive-map svg path.is-highlighted {

--- a/countries/austria.html
+++ b/countries/austria.html
@@ -39,7 +39,7 @@
           </div>
         </div>
 
-        <aside class="hero-map-card" aria-label="Austria in Europe">
+        <aside class="hero-map-card hero-visual" aria-label="Austria in Europe">
           <div class="interactive-map" data-map-src="../assets/maps/europe.svg" data-highlight="at"></div>
         </aside>
       </div>


### PR DESCRIPTION
## Summary
- align the Austria hero map wrapper with the homepage map styling
- enforce hover styling for EU countries and maintain consistent stroke width
- ensure the Austria map keeps the intended ombre glow in both themes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942b2a3a4d88320aa63ba3564c25386)