### PR TITLE
Fix country hero map theme styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Every map container must have a constant ombre/glow:
 - Light mode: blue ombre/glow (subtle blue-tinted gradient around the map).
 - Dark mode: white glow accents on a DARK base (do not switch the map container background to white/purple; only the glow/overlay is white-tinted).
 - No frames/borders around map containers.
+- The ombre/glow belongs on the hero map card container, not on the interactive map itself; in dark mode the map surface stays dark while only the surrounding glow is white-tinted.
 
 ## Map rendering constraints
 - SVG country borders must use a stroke-width of 0.8 or 0.6.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -818,7 +818,7 @@ body.theme-light .country-section-card {
 .page-country .hero-map-card.hero-visual {
   background: var(--map-ombre-light);
   padding: 12px;
-  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.14);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.14);
   min-height: auto;
   border-radius: 18px;
 }
@@ -868,9 +868,10 @@ body.theme-dark .hero-map-card {
   box-shadow: 0 14px 34px rgba(0, 0, 0, 0.42);
 }
 
-body.theme-dark .page-country .hero-map-card.hero-visual {
+body.theme-dark .page-country .hero-map-card.hero-visual,
+:root[data-theme="dark"] .page-country .hero-map-card.hero-visual {
   background: var(--map-ombre-dark);
-  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.42);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.38);
   border-radius: 18px;
 }
 
@@ -887,10 +888,23 @@ body.theme-dark .hero-map-card .interactive-map {
   box-shadow: none;
 }
 
-body.theme-dark .page-country .hero-map-card.hero-visual .interactive-map {
+body.theme-dark .page-country .hero-map-card.hero-visual .interactive-map,
+:root[data-theme="dark"] .page-country .hero-map-card.hero-visual .interactive-map {
   background: var(--bg-surface-dark);
   box-shadow: none;
   border-radius: 12px;
+}
+
+body.theme-light .page-country .hero-map-card.hero-visual,
+:root[data-theme="light"] .page-country .hero-map-card.hero-visual {
+  background: var(--map-ombre-light);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+body.theme-light .page-country .hero-map-card.hero-visual .interactive-map,
+:root[data-theme="light"] .page-country .hero-map-card.hero-visual .interactive-map {
+  background: var(--bg-page);
+  box-shadow: none;
 }
 
 :root[data-theme="light"] .hero-map-card {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const isDark = theme === 'dark';
     body.classList.toggle('theme-dark', isDark);
     body.classList.toggle('theme-light', !isDark);
-    document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
+    document.documentElement.dataset.theme = isDark ? 'dark' : 'light';
 
     const label = document.querySelector('.theme-toggle__label');
     if (label) {


### PR DESCRIPTION
## Summary
- update country hero map card styling to respect dark/light themes and place the glow on the container
- align interactive map backgrounds with theme-specific surfaces
- ensure the theme toggle updates both body classes and the document data-theme attribute, and document the glow placement rule

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942d397f55c8320b40902fad334b24c)