### PR TITLE
Adjust hero mini-map glow

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -816,11 +816,23 @@ body.theme-light .country-section-card {
 }
 
 .page-country .hero-map-card.hero-visual {
-  background: var(--map-ombre-light);
+  background: transparent;
   padding: 12px;
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.14);
   min-height: auto;
   border-radius: 18px;
+}
+
+.page-country .hero-map-card.hero-visual::before {
+  content: "";
+  position: absolute;
+  inset: -18px;
+  background: var(--map-ombre-light);
+  filter: blur(14px);
+  opacity: 0.94;
+  border-radius: 22px;
+  z-index: 0;
+  pointer-events: none;
 }
 
 .hero-map-card .interactive-map {
@@ -831,11 +843,18 @@ body.theme-light .country-section-card {
 }
 
 .page-country .hero-map-card.hero-visual .interactive-map {
+  position: relative;
+  z-index: 1;
   min-height: 240px;
-  background: var(--bg-page);
+  background: transparent;
   box-shadow: none;
   border-radius: 12px;
   --map-stroke-width: var(--map-stroke-width-mini);
+}
+
+.page-country .hero-map-card.hero-visual .interactive-map svg {
+  width: 100%;
+  max-height: 100%;
 }
 
 .hero-map-card .interactive-map svg path.eu {
@@ -870,9 +889,14 @@ body.theme-dark .hero-map-card {
 
 body.theme-dark .page-country .hero-map-card.hero-visual,
 :root[data-theme="dark"] .page-country .hero-map-card.hero-visual {
-  background: var(--map-ombre-dark);
+  background: transparent;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.38);
   border-radius: 18px;
+}
+
+body.theme-dark .page-country .hero-map-card.hero-visual::before,
+:root[data-theme="dark"] .page-country .hero-map-card.hero-visual::before {
+  background: var(--map-ombre-dark);
 }
 
 body.theme-dark .hero-map-card .interactive-map svg path.eu {
@@ -890,20 +914,20 @@ body.theme-dark .hero-map-card .interactive-map {
 
 body.theme-dark .page-country .hero-map-card.hero-visual .interactive-map,
 :root[data-theme="dark"] .page-country .hero-map-card.hero-visual .interactive-map {
-  background: var(--bg-surface-dark);
+  background: transparent;
   box-shadow: none;
   border-radius: 12px;
 }
 
 body.theme-light .page-country .hero-map-card.hero-visual,
 :root[data-theme="light"] .page-country .hero-map-card.hero-visual {
-  background: var(--map-ombre-light);
+  background: transparent;
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
 }
 
 body.theme-light .page-country .hero-map-card.hero-visual .interactive-map,
 :root[data-theme="light"] .page-country .hero-map-card.hero-visual .interactive-map {
-  background: var(--bg-page);
+  background: transparent;
   box-shadow: none;
 }
 


### PR DESCRIPTION
## Summary
- add outer glow pseudo-element for country hero mini-map cards and keep card surface transparent
- make interactive map background transparent and ensure SVG fills available space
- adapt light/dark theme overrides to use the new halo without showing an inner frame

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942d6d5452c83209aa274b852b94c0b)