### PR TITLE
Adjust home hero map styling in light mode

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1917,6 +1917,12 @@ body.theme-light.index .hero-visual .interactive-map {
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
 }
 
+body.theme-light.index .home-hero-map {
+  background: var(--bg-light-soft);
+  border: none;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.1);
+}
+
 /* Homepage-specific stroke tweak via vars (no !important chaos) */
 body.theme-dark.index {
   --map-border: rgba(255, 255, 255, 0.8);

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       </div>
 
         <div class="hero-image">
-        <div class="hero-visual">
+        <div class="hero-visual home-hero-map">
           <div class="interactive-map" data-map-src="assets/maps/europe.svg" aria-label="Interactive map of Europe"></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a dedicated class to the home hero map container
- neutralize the light-mode map wrapper glow to a soft neutral shadow while keeping other pages unchanged

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942db2ab7488320bb1a156e825cd74d)