### PR TITLE
Improve Poland edit panel layout

### DIFF
--- a/countries/poland.html
+++ b/countries/poland.html
@@ -117,7 +117,7 @@
       </article>
     </section>
 
-    <section class="country-filter-panel is-compact" data-default-topics="strict-policy" data-country-key="poland" data-save-mode="shared-link">
+    <section class="country-filter-panel" data-default-topics="strict-policy" data-country-key="poland" data-save-mode="shared-link">
       <div class="filters-heading">
         <span class="filters-eyebrow">Country filter presets</span>
         <h2 class="filters-title">Edit Poland’s highlights</h2>
@@ -133,7 +133,7 @@
             <small>Unlock with the NHL password to adjust the texts below and keep them on this page.</small>
           </div>
           <div class="lock-actions">
-            <input type="password" class="filter-password-input" placeholder="Password" aria-label="Password to unlock filter and text edits" />
+            <input type="password" class="filter-password-input" placeholder="Password" aria-label="Password to unlock filter and text edits" oninput="if (this.value.trim() === 'NHL') { const panel = this.closest('.country-filter-panel'); if (panel && panel.classList.contains('is-locked')) { panel.querySelector('.filter-lock-toggle')?.click(); } }" />
             <button type="button" class="filter-lock-toggle">Unlock</button>
           </div>
           <p class="filter-lock-status" role="status" aria-live="polite"></p>
@@ -147,19 +147,19 @@
         <div class="editable-grid">
           <label class="editable-field">
             <span>Political climate</span>
-            <textarea data-editable-field="political" data-target-selector=".section-political"></textarea>
+            <textarea data-editable-field="political" data-target-selector=".section-political" rows="6"></textarea>
           </label>
           <label class="editable-field">
             <span>Migration statistics</span>
-            <textarea data-editable-field="migration" data-target-selector=".section-migration"></textarea>
+            <textarea data-editable-field="migration" data-target-selector=".section-migration" rows="6"></textarea>
           </label>
           <label class="editable-field">
             <span>Current policies</span>
-            <textarea data-editable-field="policies" data-target-selector=".section-policies"></textarea>
+            <textarea data-editable-field="policies" data-target-selector=".section-policies" rows="6"></textarea>
           </label>
           <label class="editable-field">
             <span>Application possibilities</span>
-            <textarea data-editable-field="application" data-target-selector=".section-application"></textarea>
+            <textarea data-editable-field="application" data-target-selector=".section-application" rows="6"></textarea>
           </label>
         </div>
         <p class="editable-status" aria-live="polite"></p>


### PR DESCRIPTION
### Motivation

- Make the Poland country edit panel more usable and readable by exposing full controls and larger edit fields.
- Allow quick unlocking of the panel when the known password is entered to streamline editing.
- Reduce friction for content editors by improving textarea visibility for longer section copy.

### Description

- Removed the `is-compact` class from the Poland `country-filter-panel` so the full controls are visible on the page.
- Added an inline `oninput` handler to the password input that auto-triggers the panel unlock when the value equals `NHL`.
- Increased the visible height of editable fields by adding `rows="6"` to the four section `textarea` elements.
- Change applied to `countries/poland.html` (static HTML update).

### Testing

- Launched a local server with `python -m http.server 8000` to serve the page, which started successfully.
- Attempted automated UI validation with Playwright to capture a screenshot, but the Playwright run timed out / Chromium crashed (SIGSEGV), so the screenshot check failed.
- No unit or integration tests were run because this is a static HTML-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8e5fb8608322afe75da9c56005ad)