### PR TITLE
Set default Atlas AI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ This repository includes a GitHub Pages frontend and a Cloudflare Worker backend
 3. Deploy the Worker and note the Worker URL (for example, `https://atlas-assistant.your-domain.workers.dev`).
 4. Update the frontend `data-api-url` attribute in `/site/index.html` if you want to point to a non-`/chat` endpoint.
 
+## Atlas AI endpoint
+
+- Default endpoint: `https://atlas-ai-worker.luuk-de-vries.workers.dev/chat`
+- Override with `?api=` in the URL, for example:
+
+```
+https://<site>/?api=https://atlas-ai-worker.luuk-de-vries.workers.dev/chat
+```
+
 ## Environment variables
 
 Set these on the Worker:

--- a/assistant.html
+++ b/assistant.html
@@ -127,7 +127,7 @@
           </article>
 
           <section class="assistant-shell">
-            <div class="assistant-frame" aria-label="Atlas AI chat window">
+            <div class="assistant-frame" aria-label="Atlas AI chat window" data-api-url="https://atlas-ai-worker.luuk-de-vries.workers.dev/chat">
               <div id="chatLog" class="assistant-chat-log"></div>
               <form id="chatForm" class="assistant-input-row">
                 <input id="chatInput" type="text" placeholder="Ask about migration, asylum, borders, or EU frameworks." autocomplete="off" />

--- a/site/atlas.js
+++ b/site/atlas.js
@@ -1,10 +1,12 @@
 const chatLog = document.getElementById("chatLog");
 const chatForm = document.getElementById("chatForm");
 const chatInput = document.getElementById("chatInput");
-const queryApiUrl = new URLSearchParams(window.location.search).get("api");
-const dataApiUrl = document.body.dataset.apiUrl;
-const isLocalHost = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1";
-const apiUrl = queryApiUrl || dataApiUrl || (isLocalHost ? "/chat" : "");
+const DEFAULT_API_URL = "https://atlas-ai-worker.luuk-de-vries.workers.dev/chat";
+const queryApiParam = new URLSearchParams(window.location.search).get("api");
+const queryApiUrl = queryApiParam ? decodeURIComponent(queryApiParam) : "";
+const chatContainer = document.querySelector(".assistant-frame");
+const dataApiUrl = chatContainer ? chatContainer.dataset.apiUrl : "";
+const apiUrl = queryApiUrl || dataApiUrl || DEFAULT_API_URL;
 
 const appendMessage = (role, text, sources = []) => {
   const message = document.createElement("div");


### PR DESCRIPTION
### Motivation

- Make the Atlas AI chat UI functional by providing a sensible default Cloudflare Worker `/chat` endpoint so users no longer see the "The assistant endpoint is not configured" message.  
- Allow site operators to override the endpoint via URL query string or page attributes without changing code.  
- Keep UI and existing structure unchanged while following the repository guidance on minimal edits.  

### Description

- Add `data-api-url="https://atlas-ai-worker.luuk-de-vries.workers.dev/chat"` to the chat container element (`.assistant-frame`) in `assistant.html`.  
- Update `site/atlas.js` to introduce `DEFAULT_API_URL`, decode and prefer a `?api=` URL parameter, then the chat container `data-api-url`, and finally the default constant when selecting the endpoint.  
- Ensure all fetch calls use the resolved `apiUrl` variable (no hardcoded keys or endpoints in the request body).  
- Document the default endpoint and the `?api=` override in `README.md` with an example usage.  

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee2e6b0a48322a4a1cbf7999da48c)