### PR TITLE
Fix Atlas AI chat endpoint handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository includes a GitHub Pages frontend and a Cloudflare Worker backend
 
 ## Atlas AI endpoint
 
-- Default endpoint: `https://atlas-ai-worker.luuk-de-vries.workers.dev/chat`
+- Default endpoint: `https://atlas-ai-worker.luuk-de-vries.workers.dev/chat` (set on the chat container `data-api-url` attribute).
 - Override with `?api=` in the URL, for example:
 
 ```

--- a/site/index.html
+++ b/site/index.html
@@ -109,7 +109,7 @@
   <main class="page">
     <h1>Atlas AI Assistant</h1>
     <p class="helper-text">Ask about migration policy summaries, EU framework explanations, or comparisons between EU Member States.</p>
-    <section class="chat-card" aria-live="polite">
+    <section class="chat-card" aria-live="polite" data-api-url="https://atlas-ai-worker.luuk-de-vries.workers.dev/chat">
       <div id="chatLog" class="chat-log"></div>
       <form id="chatForm" class="input-row">
         <input id="chatInput" type="text" placeholder="Ask a question about migration, asylum, borders, or EU frameworks." autocomplete="off" />


### PR DESCRIPTION
### Motivation

- Fix unreliable chat behavior where the UI showed “No response received” or “assistant endpoint is not configured”.
- Ensure the frontend picks the correct assistant endpoint and makes requests compatible with the Cloudflare Worker response shape.
- Provide minimal debugging logs to aid in diagnosing endpoint issues in the browser console.
- Document the default endpoint and how to override it.

### Description

- Set the default endpoint on the chat container with `data-api-url="https://atlas-ai-worker.luuk-de-vries.workers.dev/chat"` in `site/index.html`.
- Improve endpoint selection in `site/atlas.js` to prefer `?api=...` (decoded), then the chat container `data-api-url`, then the `DEFAULT_API_URL`, and log the chosen URL with `console.info`.
- Send POST requests with `Content-Type: application/json` and robustly parse responses by reading `response.text()` then `JSON.parse`, displaying the first available of `data.reply || data.response || data.message`, and showing a clear error for non-JSON responses while logging non-OK HTTP statuses.
- Update `README.md` to note the default endpoint location and the `?api=` override mechanism.

### Testing

- No automated tests were run for this change.
- Changes are limited to `site/atlas.js`, `site/index.html`, and `README.md` and are minimal to preserve UI and styling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee82c524083228b94787f0bdffaea)