### PR TITLE
Render Atlas AI assistant replies as sanitized Markdown

### DIFF
--- a/assistant.html
+++ b/assistant.html
@@ -59,6 +59,21 @@
   .assistant-chat-log .message .message-content li:last-child {
     margin-bottom: 0;
   }
+  .assistant-chat-log .message.assistant .message-content table {
+    border-collapse: collapse;
+    width: 100%;
+  }
+  .assistant-chat-log .message.assistant .message-content th,
+  .assistant-chat-log .message.assistant .message-content td {
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    padding: 8px;
+    vertical-align: top;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+  }
+  .assistant-chat-log .message.assistant .message-content tr:nth-child(even) {
+    background: rgba(0, 0, 0, 0.03);
+  }
   .assistant-chat-log .message.user {
     align-self: flex-end;
     background: var(--bg-soft, #e9f0fb);
@@ -202,6 +217,8 @@
   </footer>
 
   <script src="assets/js/main.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="site/atlas.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Assistant responses from the worker are returned as Markdown (tables, links, bullets) but were being inserted as plain text, which broke formatting and links. 
- The goal is to render assistant messages as Markdown while keeping user messages plain text and preserving the existing chat UI.

### Description
- Load `marked` and `DOMPurify` via CDN in `assistant.html` and add minimal table CSS for assistant messages to improve table rendering and wrapping. 
- Replace the ad-hoc plaintext-to-HTML renderer in `site/atlas.js` with `renderAssistantContent` that uses `marked.parse(md, { mangle:false, headerIds:false })` and `DOMPurify.sanitize(html)` when available, falling back to escaped plain text. 
- Ensure assistant-only links open safely in a new tab by adding `target="_blank"` and `rel="noopener noreferrer"` to anchors inside assistant message containers. 
- Keep user messages as plain text and do not change other UI structure or behavior.

### Testing
- Started a local `python -m http.server` and loaded `assistant.html` with Playwright, capturing a screenshot of the rendered assistant page which completed successfully. 
- Verified the page loads the `marked` and `DOMPurify` scripts and the assistant welcome message is rendered via the new markdown flow in the browser screenshot. 
- No unit tests were added or run for this change. 
- All automated steps performed (server start + Playwright load/screenshot) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef382274c83228712c48ef43330a5)