### PR TITLE
Enable markdown tables in Atlas AI responses

### DIFF
--- a/backend/worker.js
+++ b/backend/worker.js
@@ -143,8 +143,8 @@ export default {
       .map((item) => `Source: ${item.path}\n${item.chunk}`)
       .join("\n\n");
 
-    const systemPrompt = "You are the Atlas AI Assistant. Use the provided Atlas sources to answer questions about migration policy, political climate, and EU frameworks. Use short paragraphs, headings, and bullet points. Avoid long walls of text. Keep answers concise. If the sources are insufficient, say so and suggest which Atlas documents to add.";
-    const userPrompt = `User question: ${message}\n\nAtlas sources:\n${context}\n\nAnswer the question and include a \"Sources (Atlas)\" list based on the provided sources.`;
+    const systemPrompt = "You are the Atlas AI Assistant. Use the provided Atlas sources to answer questions about migration policy, political climate, and EU frameworks. Use short paragraphs, headings, and bullet points. Use markdown tables when comparisons or structured data help. Avoid long walls of text. Keep answers concise. If the sources are insufficient, say so and suggest which Atlas documents to add.";
+    const userPrompt = `User question: ${message}\n\nAtlas sources:\n${context}\n\nAnswer the question in markdown and include a \"Sources (Atlas)\" list based on the provided sources.`;
 
     let answerText = "";
     try {

--- a/site/atlas.js
+++ b/site/atlas.js
@@ -20,8 +20,16 @@ const escapeHtml = (value) =>
 const renderAssistantContent = (markdownText) => {
   const safeText = markdownText || "";
   if (typeof marked !== "undefined" && typeof DOMPurify !== "undefined") {
-    const html = marked.parse(safeText, { mangle: false, headerIds: false });
-    return DOMPurify.sanitize(html);
+    const html = marked.parse(safeText, {
+      mangle: false,
+      headerIds: false,
+      gfm: true,
+      breaks: true,
+    });
+    return DOMPurify.sanitize(html, {
+      ADD_TAGS: ["table", "thead", "tbody", "tr", "th", "td"],
+      ADD_ATTR: ["colspan", "rowspan", "align"],
+    });
   }
   return `<p>${escapeHtml(safeText)}</p>`;
 };

--- a/site/index.html
+++ b/site/index.html
@@ -83,6 +83,25 @@
     .message .message-content li:last-child {
       margin-bottom: 0;
     }
+    .message .message-content table {
+      border-collapse: collapse;
+      width: 100%;
+    }
+    .message .message-content th,
+    .message .message-content td {
+      border: 1px solid var(--border-color);
+      padding: 8px;
+      vertical-align: top;
+      word-break: break-word;
+      overflow-wrap: anywhere;
+    }
+    .message .message-content th {
+      background: var(--assistant-bg);
+      text-align: left;
+    }
+    .message .message-content tr:nth-child(even) {
+      background: var(--surface);
+    }
     .message.user {
       align-self: flex-end;
       background: var(--user-bg);


### PR DESCRIPTION
### Motivation
- Improve the Atlas AI assistant so it can return and render structured comparison data using markdown tables. 
- Allow the frontend to safely display tables produced by the assistant without stripping essential table markup. 
- Encourage the model to produce markdown output when tables are helpful for clarity. 

### Description
- Enable GFM parsing with `marked` and allow line breaks in `site/atlas.js` by setting `gfm: true` and `breaks: true`. 
- Allow sanitized table tags and attributes in `site/atlas.js` by adding `ADD_TAGS: ["table","thead","tbody","tr","th","td"]` and `ADD_ATTR: ["colspan","rowspan","align"]` to `DOMPurify.sanitize`. 
- Update the assistant system/user prompts in `backend/worker.js` to recommend using markdown tables for comparisons and to return answers in markdown. 
- Add CSS table styling to the standalone assistant UI in `site/index.html` so tables are readable and consistent with the theme. 

### Testing
- Started a local dev server with `python -m http.server` and served the site for manual rendering. 
- Ran a Playwright smoke test that injected a sample table into the assistant chat and saved a screenshot to `artifacts/assistant-table.png`, confirming table rendering succeeded. 
- Verified the changes were committed to the repo (`git commit` completed). 
- No automated unit tests were added for these static/frontend changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f70d234c08322b241394d15a6a51e)