### PR TITLE
Remove editable panels from country pages

### DIFF
--- a/countries/italy.html
+++ b/countries/italy.html
@@ -82,65 +82,6 @@
       </article>
     </section>
 
-    <section class="country-filter-panel" data-default-topics="strict-policy humanitarian-focus labour-migration" data-country-key="italy">
-      <div class="filters-heading">
-        <span class="filters-eyebrow">Country filter presets</span>
-        <h2 class="filters-title">Select the themes that fit Italy</h2>
-      </div>
-      <p class="filter-description">
-        Choose which topics describe Italy best. Once unlocked, you can also edit the section text below. Everything is saved locally.
-      </p>
-      <div class="filters-controls">
-        <div class="filter-lock">
-          <span class="lock-icon" aria-hidden="true">🔒</span>
-          <div>
-            <span class="lock-label">Locked controls</span>
-            <small>Enter the NHL password to update filters and section copy at the bottom of the page.</small>
-          </div>
-          <div class="lock-actions">
-            <input type="password" class="filter-password-input" placeholder="Password" aria-label="Password to unlock filter and text edits" />
-            <button type="button" class="filter-lock-toggle">Unlock</button>
-          </div>
-          <p class="filter-lock-status" role="status" aria-live="polite"></p>
-        </div>
-      </div>
-      <div class="editable-texts">
-        <span class="filter-eyebrow">Section text (English)</span>
-        <p class="filter-description">
-          Adjust the copy for each country section. Changes stay in this browser once the NHL password is entered.
-        </p>
-        <label class="editable-field">
-          <span>Political climate</span>
-          <textarea data-editable-field="political" data-target-selector=".section-political"></textarea>
-        </label>
-        <label class="editable-field">
-          <span>Migration statistics</span>
-          <textarea data-editable-field="migration" data-target-selector=".section-migration"></textarea>
-        </label>
-        <label class="editable-field">
-          <span>Current policies</span>
-          <textarea data-editable-field="policies" data-target-selector=".section-policies"></textarea>
-        </label>
-        <label class="editable-field">
-          <span>Application possibilities</span>
-          <textarea data-editable-field="application" data-target-selector=".section-application"></textarea>
-        </label>
-        <p class="editable-status" aria-live="polite"></p>
-      </div>
-      <div class="topic-filter">
-        <span class="filter-eyebrow">Topics</span>
-        <div class="filter-chips">
-          <button type="button" class="filter-chip" data-topic="high-recognition">High recognition rate</button>
-          <button type="button" class="filter-chip" data-topic="strict-policy">Strict asylum policy</button>
-          <button type="button" class="filter-chip" data-topic="labour-migration">High labour migration</button>
-          <button type="button" class="filter-chip" data-topic="humanitarian-focus">Humanitarian focus</button>
-        </div>
-      </div>
-      <div class="filter-actions">
-        <button type="button" class="filter-apply">Filter countries</button>
-        <button type="button" class="filter-reset">Reset to defaults</button>
-      </div>
-    </section>
   </main>
 
   <footer class="site-footer">

--- a/countries/luxembourg.html
+++ b/countries/luxembourg.html
@@ -125,65 +125,6 @@
       </article>
     </section>
 
-    <section class="country-filter-panel" data-default-topics="high-recognition humanitarian-focus" data-country-key="luxembourg">
-      <div class="filters-heading">
-        <span class="filters-eyebrow">Country filter presets</span>
-        <h2 class="filters-title">Select the themes that fit Luxembourg</h2>
-      </div>
-      <p class="filter-description">
-        Choose which topics describe Luxembourg best. Once unlocked, you can also edit the section text below. Everything is saved locally.
-      </p>
-      <div class="filters-controls">
-        <div class="filter-lock">
-          <span class="lock-icon" aria-hidden="true">🔒</span>
-          <div>
-            <span class="lock-label">Locked controls</span>
-            <small>Enter the NHL password to update filters and section copy at the bottom of the page.</small>
-          </div>
-          <div class="lock-actions">
-            <input type="password" class="filter-password-input" placeholder="Password" aria-label="Password to unlock filter and text edits" />
-            <button type="button" class="filter-lock-toggle">Unlock</button>
-          </div>
-          <p class="filter-lock-status" role="status" aria-live="polite"></p>
-        </div>
-      </div>
-      <div class="editable-texts">
-        <span class="filter-eyebrow">Section text (English)</span>
-        <p class="filter-description">
-          Adjust the copy for each country section. Changes stay in this browser once the NHL password is entered.
-        </p>
-        <label class="editable-field">
-          <span>Political climate</span>
-          <textarea data-editable-field="political" data-target-selector=".section-political"></textarea>
-        </label>
-        <label class="editable-field">
-          <span>Migration statistics</span>
-          <textarea data-editable-field="migration" data-target-selector=".section-migration"></textarea>
-        </label>
-        <label class="editable-field">
-          <span>Current policies</span>
-          <textarea data-editable-field="policies" data-target-selector=".section-policies"></textarea>
-        </label>
-        <label class="editable-field">
-          <span>Application possibilities</span>
-          <textarea data-editable-field="application" data-target-selector=".section-application"></textarea>
-        </label>
-        <p class="editable-status" aria-live="polite"></p>
-      </div>
-      <div class="topic-filter">
-        <span class="filter-eyebrow">Topics</span>
-        <div class="filter-chips">
-          <button type="button" class="filter-chip" data-topic="high-recognition">High recognition rate</button>
-          <button type="button" class="filter-chip" data-topic="strict-policy">Strict asylum policy</button>
-          <button type="button" class="filter-chip" data-topic="labour-migration">High labour migration</button>
-          <button type="button" class="filter-chip" data-topic="humanitarian-focus">Humanitarian focus</button>
-        </div>
-      </div>
-      <div class="filter-actions">
-        <button type="button" class="filter-apply">Filter countries</button>
-        <button type="button" class="filter-reset">Reset to defaults</button>
-      </div>
-    </section>
   </main>
 
   <footer class="site-footer">

--- a/countries/poland.html
+++ b/countries/poland.html
@@ -117,68 +117,6 @@
       </article>
     </section>
 
-    <section class="country-filter-panel" data-default-topics="strict-policy" data-country-key="poland" data-save-mode="shared-link">
-      <div class="filters-heading">
-        <span class="filters-eyebrow">Country filter presets</span>
-        <h2 class="filters-title">Edit Poland’s highlights</h2>
-      </div>
-      <p class="filter-description">
-        Enter the password <strong>NHL</strong> at the bottom to unlock edits. Press Save to update the texts on this page for everyone using the link.
-      </p>
-      <div class="filters-controls">
-        <div class="filter-lock">
-          <span class="lock-icon" aria-hidden="true">🔒</span>
-          <div>
-            <span class="lock-label">Locked controls</span>
-            <small>Unlock with the NHL password to adjust the texts below and keep them on this page.</small>
-          </div>
-          <div class="lock-actions">
-            <input type="password" class="filter-password-input" placeholder="Password" aria-label="Password to unlock filter and text edits" oninput="if (this.value.trim() === 'NHL') { const panel = this.closest('.country-filter-panel'); if (panel && panel.classList.contains('is-locked')) { panel.querySelector('.filter-lock-toggle')?.click(); } }" />
-            <button type="button" class="filter-lock-toggle">Unlock</button>
-          </div>
-          <p class="filter-lock-status" role="status" aria-live="polite"></p>
-        </div>
-      </div>
-      <div class="editable-texts">
-        <span class="filter-eyebrow">Editable sections</span>
-        <p class="filter-description">
-          Update the copy for each section once unlocked. Saving refreshes this page’s link so others can see it.
-        </p>
-        <div class="editable-grid">
-          <label class="editable-field">
-            <span>Political climate</span>
-            <textarea data-editable-field="political" data-target-selector=".section-political" rows="6"></textarea>
-          </label>
-          <label class="editable-field">
-            <span>Migration statistics</span>
-            <textarea data-editable-field="migration" data-target-selector=".section-migration" rows="6"></textarea>
-          </label>
-          <label class="editable-field">
-            <span>Current policies</span>
-            <textarea data-editable-field="policies" data-target-selector=".section-policies" rows="6"></textarea>
-          </label>
-          <label class="editable-field">
-            <span>Application possibilities</span>
-            <textarea data-editable-field="application" data-target-selector=".section-application" rows="6"></textarea>
-          </label>
-        </div>
-        <p class="editable-status" aria-live="polite"></p>
-      </div>
-      <div class="topic-filter">
-        <span class="filter-eyebrow">Topics</span>
-        <div class="filter-chips">
-          <button type="button" class="filter-chip" data-topic="high-recognition">High recognition rate</button>
-          <button type="button" class="filter-chip" data-topic="strict-policy">Strict asylum policy</button>
-          <button type="button" class="filter-chip" data-topic="labour-migration">High labour migration</button>
-          <button type="button" class="filter-chip" data-topic="humanitarian-focus">Humanitarian focus</button>
-        </div>
-      </div>
-      <div class="filter-actions">
-        <button type="button" class="filter-save">Save changes</button>
-        <button type="button" class="filter-reset">Reset</button>
-        <button type="button" class="filter-apply">Filter countries</button>
-      </div>
-    </section>
   </main>
 
   <footer class="site-footer">


### PR DESCRIPTION
### Motivation
- Several country pages included a bottom in-page editable/filter panel (`country-filter-panel`) that exposed a local edit form; these panels are being removed to disable that in-page editing UI.
- The change is limited to pages that contained the panel implementation rather than a site-wide refactor. 

### Description
- Removed the `<section class="country-filter-panel" ...>` editable/filter panel from `countries/italy.html`, `countries/luxembourg.html`, and `countries/poland.html`.
- Preserved existing HTML structure and footer markup so page layout remains stable and no classes or IDs were renamed or moved.
- No CSS, JavaScript, or other files were modified as part of this change. 

### Testing
- Served the site locally with `python -m http.server 8000` and captured a Playwright screenshot of `http://127.0.0.1:8000/countries/italy.html` to verify the panel was removed, and the screenshot artifact was produced successfully.
- Performed quick file inspections to confirm the `country-filter-panel` blocks were removed from the three target files with no other occurrences modified. 
- No unit or integration test suite was run because this is a static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696771110db48322bdff2ea7f58502fe)