### PR TITLE
Enhance compare page with full country list and dynamic profile loading

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1667,6 +1667,11 @@ body.theme-dark .filter-chip::before {
   overflow: hidden;
 }
 
+.comparison-panel.is-ready {
+  border-color: var(--cmp-panel-accent-strong);
+  transform: translateY(-2px);
+}
+
 .comparison-panel::before {
   content: "";
   position: absolute;
@@ -1685,6 +1690,10 @@ body.theme-dark .filter-chip::before {
   height: 4px;
   background: linear-gradient(90deg, var(--cmp-panel-accent-strong), transparent 70%);
   pointer-events: none;
+}
+
+.comparison-panel.is-ready::after {
+  background: linear-gradient(90deg, var(--cmp-panel-accent-strong), var(--cmp-panel-accent), transparent 80%);
 }
 
 .compare-panel-grid {
@@ -1774,6 +1783,11 @@ body.theme-dark .filter-chip::before {
   border: 1px solid var(--cmp-card-border);
   box-shadow: var(--cmp-card-shadow);
   color: var(--cmp-card-muted);
+}
+
+.compare-page .select-options li.is-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 @media (max-width: 768px) {

--- a/compare.html
+++ b/compare.html
@@ -35,8 +35,9 @@
       <header class="section-header">
         <h1>Compare Migration Policies</h1>
         <p>
-          Use this tool to compare the political climate and migration policies of two EU Member States
-          side by side. Select two countries to explore differences and similarities across key dimensions.
+          Use this tool to compare the political climate, migration statistics, policies, and application
+          pathways of two EU Member States side by side. Select two countries to explore the highlights
+          from each profile.
         </p>
       </header>
 
@@ -50,9 +51,33 @@
               </button>
               <ul class="select-options" role="listbox">
                 <li data-value="" role="option" aria-selected="true" tabindex="0">Select a country</li>
-                <li data-value="italy" role="option" tabindex="0">Italy</li>
-                <li data-value="germany" role="option" tabindex="0">Germany</li>
+                <li data-value="austria" role="option" tabindex="0">Austria</li>
+                <li data-value="belgium" role="option" tabindex="0">Belgium</li>
+                <li data-value="bulgaria" role="option" tabindex="0">Bulgaria</li>
+                <li data-value="croatia" role="option" tabindex="0">Croatia</li>
+                <li data-value="cyprus" role="option" tabindex="0">Cyprus</li>
+                <li data-value="czechia" role="option" tabindex="0">Czechia</li>
+                <li data-value="denmark" role="option" tabindex="0">Denmark</li>
+                <li data-value="estonia" role="option" tabindex="0">Estonia</li>
+                <li data-value="finland" role="option" tabindex="0">Finland</li>
                 <li data-value="france" role="option" tabindex="0">France</li>
+                <li data-value="germany" role="option" tabindex="0">Germany</li>
+                <li data-value="greece" role="option" tabindex="0">Greece</li>
+                <li data-value="hungary" role="option" tabindex="0">Hungary</li>
+                <li data-value="ireland" role="option" tabindex="0">Ireland</li>
+                <li data-value="italy" role="option" tabindex="0">Italy</li>
+                <li data-value="latvia" role="option" tabindex="0">Latvia</li>
+                <li data-value="lithuania" role="option" tabindex="0">Lithuania</li>
+                <li data-value="luxembourg" role="option" tabindex="0">Luxembourg</li>
+                <li data-value="malta" role="option" tabindex="0">Malta</li>
+                <li data-value="netherlands" role="option" tabindex="0">Netherlands</li>
+                <li data-value="poland" role="option" tabindex="0">Poland</li>
+                <li data-value="portugal" role="option" tabindex="0">Portugal</li>
+                <li data-value="romania" role="option" tabindex="0">Romania</li>
+                <li data-value="slovakia" role="option" tabindex="0">Slovakia</li>
+                <li data-value="slovenia" role="option" tabindex="0">Slovenia</li>
+                <li data-value="spain" role="option" tabindex="0">Spain</li>
+                <li data-value="sweden" role="option" tabindex="0">Sweden</li>
               </ul>
             </div>
           </div>
@@ -61,29 +86,29 @@
 
           <div class="comparison-panel-metrics">
             <div class="compare-panel-grid">
-              <div class="metric-card compare-card" data-metric="stance">
-                <h3>Political stance</h3>
+              <div class="metric-card compare-card" data-metric="political-climate">
+                <h3>Political climate</h3>
                 <p>
                   The country's current migration stance leans toward balanced cooperation, blending national security considerations with humanitarian obligations. Narrative shifts over election cycles keep the debate active and nuanced within cabinet discussions.
                 </p>
               </div>
 
-              <div class="metric-card compare-card" data-metric="salience">
-                <h3>Salience in domestic politics</h3>
+              <div class="metric-card compare-card" data-metric="migration-statistics">
+                <h3>Migration statistics</h3>
                 <p>
                   Migration regularly features in talk shows, parliamentary questions, and civic forums. Peaks occur around border incidents or labour market reforms, prompting rapid responses from leading parties and media commentators.
                 </p>
               </div>
 
-              <div class="metric-card compare-card" data-metric="eu-alignment">
-                <h3>EU alignment</h3>
+              <div class="metric-card compare-card" data-metric="current-policies">
+                <h3>Current policies</h3>
                 <p>
                   Implementation of EU migration and asylum rules generally tracks common standards, with ongoing adjustments to meet new pact obligations. Cooperation with agencies remains steady, supported by technical assistance.
                 </p>
               </div>
 
-              <div class="metric-card compare-card" data-metric="capacity">
-                <h3>Implementation capacity</h3>
+              <div class="metric-card compare-card" data-metric="application-possibilities">
+                <h3>Application possibilities</h3>
                 <p>
                   Administrative structures coordinate across ministries and regional authorities, with dedicated budgets for reception and integration. Workforce planning and digital tools are being scaled to manage fluctuating arrivals.
                 </p>
@@ -101,9 +126,33 @@
               </button>
               <ul class="select-options" role="listbox">
                 <li data-value="" role="option" aria-selected="true" tabindex="0">Select a country</li>
-                <li data-value="italy" role="option" tabindex="0">Italy</li>
-                <li data-value="germany" role="option" tabindex="0">Germany</li>
+                <li data-value="austria" role="option" tabindex="0">Austria</li>
+                <li data-value="belgium" role="option" tabindex="0">Belgium</li>
+                <li data-value="bulgaria" role="option" tabindex="0">Bulgaria</li>
+                <li data-value="croatia" role="option" tabindex="0">Croatia</li>
+                <li data-value="cyprus" role="option" tabindex="0">Cyprus</li>
+                <li data-value="czechia" role="option" tabindex="0">Czechia</li>
+                <li data-value="denmark" role="option" tabindex="0">Denmark</li>
+                <li data-value="estonia" role="option" tabindex="0">Estonia</li>
+                <li data-value="finland" role="option" tabindex="0">Finland</li>
                 <li data-value="france" role="option" tabindex="0">France</li>
+                <li data-value="germany" role="option" tabindex="0">Germany</li>
+                <li data-value="greece" role="option" tabindex="0">Greece</li>
+                <li data-value="hungary" role="option" tabindex="0">Hungary</li>
+                <li data-value="ireland" role="option" tabindex="0">Ireland</li>
+                <li data-value="italy" role="option" tabindex="0">Italy</li>
+                <li data-value="latvia" role="option" tabindex="0">Latvia</li>
+                <li data-value="lithuania" role="option" tabindex="0">Lithuania</li>
+                <li data-value="luxembourg" role="option" tabindex="0">Luxembourg</li>
+                <li data-value="malta" role="option" tabindex="0">Malta</li>
+                <li data-value="netherlands" role="option" tabindex="0">Netherlands</li>
+                <li data-value="poland" role="option" tabindex="0">Poland</li>
+                <li data-value="portugal" role="option" tabindex="0">Portugal</li>
+                <li data-value="romania" role="option" tabindex="0">Romania</li>
+                <li data-value="slovakia" role="option" tabindex="0">Slovakia</li>
+                <li data-value="slovenia" role="option" tabindex="0">Slovenia</li>
+                <li data-value="spain" role="option" tabindex="0">Spain</li>
+                <li data-value="sweden" role="option" tabindex="0">Sweden</li>
               </ul>
             </div>
           </div>
@@ -112,29 +161,29 @@
 
           <div class="comparison-panel-metrics">
             <div class="compare-panel-grid">
-              <div class="metric-card compare-card" data-metric="stance">
-                <h3>Political stance</h3>
+              <div class="metric-card compare-card" data-metric="political-climate">
+                <h3>Political climate</h3>
                 <p>
                   The government frames migration through stability and partnership, balancing border management with international protection duties. Statements from key ministers emphasise predictability and cooperation with neighbouring states.
                 </p>
               </div>
 
-              <div class="metric-card compare-card" data-metric="salience">
-                <h3>Salience in domestic politics</h3>
+              <div class="metric-card compare-card" data-metric="migration-statistics">
+                <h3>Migration statistics</h3>
                 <p>
                   Media coverage intensifies around legislative updates and migration-related court rulings. Civil society forumsand academic reports feed into televised debates that shape voter perceptions throughout the year.
                 </p>
               </div>
 
-              <div class="metric-card compare-card" data-metric="eu-alignment">
-                <h3>EU alignment</h3>
+              <div class="metric-card compare-card" data-metric="current-policies">
+                <h3>Current policies</h3>
                 <p>
                   Compliance with EU frameworks is actively managed through inter-ministerial taskforces. Pilot projects with EU agencies test new screening approaches and improve interoperability with partner systems.
                 </p>
               </div>
 
-              <div class="metric-card compare-card" data-metric="capacity">
-                <h3>Implementation capacity</h3>
+              <div class="metric-card compare-card" data-metric="application-possibilities">
+                <h3>Application possibilities</h3>
                 <p>
                   Reception networks leverage municipal facilities and partnerships with NGOs. Investment in digital case management aims to streamline procedures and reduce processing backlogs during peak periods.
                 </p>


### PR DESCRIPTION
### Motivation
- Make the Compare page useful beyond a static mock by surfacing real country profile highlights and preventing duplicate selections. 
- Align comparison tiles with the actual section headings used on country profile pages so panels can show relevant content or sensible fallbacks.

### Description
- Expanded the country pickers in `compare.html` to include all EU member states and updated the page intro copy. 
- Reworked the compare metrics to match profile sections (`political-climate`, `migration-statistics`, `current-policies`, `application-possibilities`).
- Added client logic in `assets/js/main.js` to index `countries.html`, fetch individual `countries/<slug>.html` profiles, populate panels with profile text (or generate fallback insights based on topic tags), prevent selecting the same country twice, and disable already-selected options. 
- Touched `assets/css/style.css` to visually mark active panels (`.comparison-panel.is-ready`) and disabled select options (`.select-options li.is-disabled`).

### Testing
- Launched a local static server with `python -m http.server` and verified `compare.html` responded over HTTP (server responded 200). 
- Attempted automated UI checks with Playwright to open `http://127.0.0.1:8000/compare.html` and exercise the custom selects, but the Playwright runs timed out / crashed in the execution environment and screenshots could not be captured, so end-to-end UI assertions did not complete successfully. 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967704326fc8322b1e183cfe8e9ce12)